### PR TITLE
Improved API Keys

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>edge-patron</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
+  <version>0.1.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Edge API - Patron Empowerment</name>

--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>edge-common</artifactId>
-      <version>0.1.3-SNAPSHOT</version>
+      <version>0.2.1-SNAPSHOT</version>
     </dependency>
 
     <!-- Only needed for AwsParamStore -->

--- a/src/test/java/org/folio/edge/patron/MainVerticleTest.java
+++ b/src/test/java/org/folio/edge/patron/MainVerticleTest.java
@@ -19,12 +19,12 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
 import java.util.ArrayList;
-import java.util.Base64;
 import java.util.List;
 import java.util.UUID;
 
 import org.apache.http.HttpHeaders;
 import org.apache.log4j.Logger;
+import org.folio.edge.core.InstitutionalUserHelper;
 import org.folio.edge.core.utils.test.TestUtils;
 import org.folio.edge.patron.model.Account;
 import org.folio.edge.patron.model.Hold;
@@ -52,9 +52,9 @@ public class MainVerticleTest {
   private static final String itemId = UUID.randomUUID().toString();
   private static final String instanceId = UUID.randomUUID().toString();
   private static final String holdId = UUID.randomUUID().toString();
-  private static final String apiKey = "ZGlrdQ==";
+  private static final String apiKey = "Z1luMHVGdjNMZl9kaWt1X2Rpa3U=";
   private static final String badApiKey = "ZnMwMDAwMDAwMA==0000";
-  private static final String unknownTenantApiKey = "Ym9ndXN0ZW5hbnQ=";
+  private static final String unknownTenantApiKey = "Z1luMHVGdjNMZl9ib2d1c19ib2d1cw==";
 
   private static final long requestTimeoutMs = 3000L;
 
@@ -67,7 +67,7 @@ public class MainVerticleTest {
     int serverPort = TestUtils.getPort();
 
     List<String> knownTenants = new ArrayList<>();
-    knownTenants.add(new String(Base64.getUrlDecoder().decode(apiKey)));
+    knownTenants.add(InstitutionalUserHelper.parseApiKey(apiKey).tenantId);
 
     mockOkapi = spy(new PatronMockOkapi(okapiPort, knownTenants));
     mockOkapi.start(context);


### PR DESCRIPTION
Utilize the new API key format in edge-common-0.2.1-SNAPSHOT...

Incorporates a salt/clientId and an institutional userId, to make it harder to guess an API key.

e.g.
```
clientID/salt = gYn0uFv3Lf (random string)
tenantID = fs00000000
username = fs00000000 (same as tenantID)
delim = "_"

apiKey = urlBase64(gYn0uFv3Lf_fs00000000_fs00000000) 
apiKey = Z1luMHVGdjNMZl9mczAwMDAwMDAwX2ZzMDAwMDAwMD=A
```

The benefit of doing this is that the clientId would only be known to us, so even if someone knew the tenantId, and was able to find or guess the institutional user's username, they would still have to guess or brute force the clientID.