### PR TITLE
Add feeFineID to charges

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>edge-patron</artifactId>
-  <version>0.1.0-SNAPSHOT</version>
+  <version>0.1.1-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Edge API - Patron Empowerment</name>

--- a/ramls/charge.json
+++ b/ramls/charge.json
@@ -30,6 +30,11 @@
     "reason": {
       "type": "string",
       "description": "The reason for this charge"
+    },
+    "feeFineId": {
+      "type": "string",
+      "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$",
+      "description": "The UUID of the fee/fine for this charge"
     }
   }
 }

--- a/ramls/patron.xsd
+++ b/ramls/patron.xsd
@@ -67,6 +67,7 @@
       <xs:element name="description" type="xs:string" minOccurs="0" maxOccurs="1"/>
       <xs:element name="state" type="xs:string" minOccurs="0" maxOccurs="1"/>
       <xs:element name="reason" type="xs:string" minOccurs="0" maxOccurs="1"/>
+      <xs:element name="feeFineId" type="xs:string" minOccurs="0" maxOccurs="1"/>
     </xs:sequence>
   </xs:complexType>
 </xs:element>

--- a/src/main/java/org/folio/edge/patron/PatronHandler.java
+++ b/src/main/java/org/folio/edge/patron/PatronHandler.java
@@ -75,9 +75,9 @@ public class PatronHandler {
 
     final PatronOkapiClient client = ocf.getPatronOkapiClient(clientInfo.tenantId);
 
-    iuHelper.getToken(client, 
-        clientInfo.clientId, 
-        clientInfo.tenantId, 
+    iuHelper.getToken(client,
+        clientInfo.clientId,
+        clientInfo.tenantId,
         clientInfo.username)
       .exceptionally(t -> {
         accessDenied(ctx);

--- a/src/main/java/org/folio/edge/patron/model/Charge.java
+++ b/src/main/java/org/folio/edge/patron/model/Charge.java
@@ -24,14 +24,17 @@ public final class Charge {
   public final String description;
   public final String state;
   public final String reason;
+  public final String feeFineId;
 
-  private Charge(Item item, Money chargeAmount, Date accrualDate, String description, String state, String reason) {
+  private Charge(Item item, Money chargeAmount, Date accrualDate, String description, String state, String reason,
+      String feeFineId) {
     this.item = item;
     this.chargeAmount = chargeAmount;
     this.accrualDate = accrualDate;
     this.description = description;
     this.state = state;
     this.reason = reason;
+    this.feeFineId = feeFineId;
   }
 
   public static Builder builder() {
@@ -45,6 +48,7 @@ public final class Charge {
     private String description;
     private String state;
     private String reason;
+    private String feeFineId;
 
     @JsonProperty("item")
     public Builder item(Item item) {
@@ -82,8 +86,14 @@ public final class Charge {
       return this;
     }
 
+    @JsonProperty("feeFineId")
+    public Builder feeFineId(String feeFineId) {
+      this.feeFineId = feeFineId;
+      return this;
+    }
+
     public Charge build() {
-      return new Charge(item, chargeAmount, accrualDate, description, state, reason);
+      return new Charge(item, chargeAmount, accrualDate, description, state, reason, feeFineId);
     }
   }
 
@@ -97,6 +107,7 @@ public final class Charge {
     result = prime * result + ((description == null) ? 0 : description.hashCode());
     result = prime * result + ((item == null) ? 0 : item.hashCode());
     result = prime * result + ((reason == null) ? 0 : reason.hashCode());
+    result = prime * result + ((feeFineId == null) ? 0 : feeFineId.hashCode());
     result = prime * result + ((state == null) ? 0 : state.hashCode());
     return result;
   }
@@ -147,6 +158,13 @@ public final class Charge {
         return false;
       }
     } else if (!reason.equals(other.reason)) {
+      return false;
+    }
+    if (feeFineId == null) {
+      if (other.feeFineId != null) {
+        return false;
+      }
+    } else if (!feeFineId.equals(other.feeFineId)) {
       return false;
     }
     if (state == null) {

--- a/src/main/java/org/folio/edge/patron/utils/PatronOkapiClient.java
+++ b/src/main/java/org/folio/edge/patron/utils/PatronOkapiClient.java
@@ -152,5 +152,5 @@ public class PatronOkapiClient extends OkapiClient {
         responseHandler,
         exceptionHandler);
   }
-  
+
 }

--- a/src/test/java/org/folio/edge/patron/model/AccountTest.java
+++ b/src/test/java/org/folio/edge/patron/model/AccountTest.java
@@ -124,6 +124,7 @@ public class AccountTest {
 
     charges.add(Charge.builder()
       .item(overdueCheckedOutItem1)
+      .feeFineId(UUID.randomUUID().toString())
       .accrualDate(new Date(accrualTs))
       .chargeAmount(new Money(1.23f, Currency.getInstance("USD").getCurrencyCode()))
       .description("late fee")
@@ -133,6 +134,7 @@ public class AccountTest {
 
     charges.add(Charge.builder()
       .item(overdueCheckedOutItem2)
+      .feeFineId(UUID.randomUUID().toString())
       .accrualDate(new Date(accrualTs + (2 * DAY_IN_MILLIS)))
       .chargeAmount(new Money(1.12f, Currency.getInstance("USD").getCurrencyCode()))
       .description("late fee")

--- a/src/test/java/org/folio/edge/patron/model/ChargeTest.java
+++ b/src/test/java/org/folio/edge/patron/model/ChargeTest.java
@@ -60,6 +60,7 @@ public class ChargeTest {
 
     charge = Charge.builder()
       .item(item)
+      .feeFineId(UUID.randomUUID().toString())
       .accrualDate(new Date(accrualTs))
       .chargeAmount(new Money(1.23f, Currency.getInstance("USD").getCurrencyCode()))
       .description("late fee")

--- a/src/test/java/org/folio/edge/patron/model/loanTest.java
+++ b/src/test/java/org/folio/edge/patron/model/loanTest.java
@@ -67,7 +67,7 @@ public class loanTest {
       .newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
     Schema schema = schemaFactory.newSchema(new File(XSD));
     xmlValidator = schema.newValidator();
-    
+
     FormatValidator formatValidator = new FormatValidator() {
 
       @Override

--- a/src/test/java/org/folio/edge/patron/utils/PatronMockOkapi.java
+++ b/src/test/java/org/folio/edge/patron/utils/PatronMockOkapi.java
@@ -324,6 +324,7 @@ public class PatronMockOkapi extends MockOkapi {
   public static Charge getCharge(String itemId) {
     return Charge.builder()
       .item(getItem(itemId_overdue))
+      .feeFineId(UUID.randomUUID().toString())
       .chargeAmount(new Money(1.23f, Currency.getInstance("USD").getCurrencyCode()))
       .accrualDate(new Date(accrualDateTs))
       .description("late fee")

--- a/src/test/java/org/folio/edge/patron/utils/PatronMockOkapi.java
+++ b/src/test/java/org/folio/edge/patron/utils/PatronMockOkapi.java
@@ -51,6 +51,7 @@ public class PatronMockOkapi extends MockOkapi {
   public static final String itemId = UUID.randomUUID().toString();
   public static final String itemId_notFound = UUID.randomUUID().toString();
   public static final String patronId_notFound = UUID.randomUUID().toString();
+  public static final String feeFineId = UUID.randomUUID().toString();
 
   public static final long checkedOutTs = System.currentTimeMillis() - (34 * DAY_IN_MILLIS);
   public static final long dueDateTs = checkedOutTs + (20 * DAY_IN_MILLIS);
@@ -324,7 +325,7 @@ public class PatronMockOkapi extends MockOkapi {
   public static Charge getCharge(String itemId) {
     return Charge.builder()
       .item(getItem(itemId_overdue))
-      .feeFineId(UUID.randomUUID().toString())
+      .feeFineId(feeFineId)
       .chargeAmount(new Money(1.23f, Currency.getInstance("USD").getCurrencyCode()))
       .accrualDate(new Date(accrualDateTs))
       .description("late fee")


### PR DESCRIPTION
New field in the charges object: feeFineId (UUID) (see example below):

```
{
  "item" : {
    "title" : "The Inverted World",
    "author" : "Priest, Christopher",
    "instanceId" : "4d9b1d4d-af36-4672-b876-b0bbf13c3622",
    "itemId" : "09e7f3d2-ad88-4ce5-bfad-a42fc63ee41b",
    "isbn" : "0008675309"
  },
  "chargeAmount" : {
    "amount" : 1.23,
    "isoCurrencyCode" : "USD"
  },
  "accrualDate" : "2018-05-08T19:25:20.941+0000",
  "description" : "late fee",
  "state" : "outstanding",
  "reason" : "item overdue",
  "feeFineId" : "45a8a1f3-a8b5-4485-afd9-05eed31017c4"
}
```