### PR TITLE
Patron mapping

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>edge-patron</artifactId>
-  <version>0.1.1-SNAPSHOT</version>
+  <version>0.1.2-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Edge API - Patron Empowerment</name>

--- a/src/main/java/org/folio/edge/patron/Constants.java
+++ b/src/main/java/org/folio/edge/patron/Constants.java
@@ -4,7 +4,14 @@ import java.util.Currency;
 
 public class Constants {
 
+  public static final String SYS_PATRON_ID_CACHE_TTL_MS = "patron_id_cache_ttl_ms";
+  public static final String SYS_NULL_PATRON_ID_CACHE_TTL_MS = "null_patron_id_cache_ttl_ms";
+  public static final String SYS_PATRON_ID_CACHE_CAPACITY = "patron_id_cache_capacity";
+
   public static final String DEFAULT_CURRENCY_CODE = Currency.getInstance("USD").getCurrencyCode();
+  public static final long DEFAULT_PATRON_ID_CACHE_TTL_MS = 60 * 60 * 1000L;
+  public static final long DEFAULT_NULL_PATRON_ID_CACHE_TTL_MS = 30 * 1000L;
+  public static final int DEFAULT_PATRON_ID_CACHE_CAPACITY = 1000;
 
   public static final String PARAM_INCLUDE_LOANS = "includeLoans";
   public static final String PARAM_INCLUDE_CHARGES = "includeCharges";

--- a/src/main/java/org/folio/edge/patron/MainVerticle.java
+++ b/src/main/java/org/folio/edge/patron/MainVerticle.java
@@ -1,6 +1,15 @@
 package org.folio.edge.patron;
 
+import static org.folio.edge.patron.Constants.DEFAULT_NULL_PATRON_ID_CACHE_TTL_MS;
+import static org.folio.edge.patron.Constants.DEFAULT_PATRON_ID_CACHE_CAPACITY;
+import static org.folio.edge.patron.Constants.DEFAULT_PATRON_ID_CACHE_TTL_MS;
+import static org.folio.edge.patron.Constants.SYS_NULL_PATRON_ID_CACHE_TTL_MS;
+import static org.folio.edge.patron.Constants.SYS_PATRON_ID_CACHE_CAPACITY;
+import static org.folio.edge.patron.Constants.SYS_PATRON_ID_CACHE_TTL_MS;
+
+import org.apache.log4j.Logger;
 import org.folio.edge.core.EdgeVerticle;
+import org.folio.edge.patron.cache.PatronIdCache;
 import org.folio.edge.patron.utils.PatronOkapiClientFactory;
 
 import io.vertx.core.http.HttpMethod;
@@ -9,8 +18,28 @@ import io.vertx.ext.web.handler.BodyHandler;
 
 public class MainVerticle extends EdgeVerticle {
 
+  private static final Logger logger = Logger.getLogger(MainVerticle.class);
+
   public MainVerticle() {
     super();
+
+    final String patronIdCacheTtlMs = System.getProperty(SYS_PATRON_ID_CACHE_TTL_MS);
+    final long cacheTtlMs = patronIdCacheTtlMs != null ? Long.parseLong(patronIdCacheTtlMs)
+        : DEFAULT_PATRON_ID_CACHE_TTL_MS;
+    logger.info("Using patronId cache TTL (ms): " + patronIdCacheTtlMs);
+
+    final String nullTokenCacheTtlMs = System.getProperty(SYS_NULL_PATRON_ID_CACHE_TTL_MS);
+    final long failureCacheTtlMs = nullTokenCacheTtlMs != null ? Long.parseLong(nullTokenCacheTtlMs)
+        : DEFAULT_NULL_PATRON_ID_CACHE_TTL_MS;
+    logger.info("Using patronId cache TTL (ms): " + failureCacheTtlMs);
+
+    final String patronIdCacheCapacity = System.getProperty(SYS_PATRON_ID_CACHE_CAPACITY);
+    final int cacheCapacity = patronIdCacheCapacity != null ? Integer.parseInt(patronIdCacheCapacity)
+        : DEFAULT_PATRON_ID_CACHE_CAPACITY;
+    logger.info("Using patronId cache capacity: " + patronIdCacheCapacity);
+
+    // initialize the TokenCache
+    PatronIdCache.initialize(cacheTtlMs, failureCacheTtlMs, cacheCapacity);
   }
 
   @Override

--- a/src/main/java/org/folio/edge/patron/cache/PatronIdCache.java
+++ b/src/main/java/org/folio/edge/patron/cache/PatronIdCache.java
@@ -1,0 +1,82 @@
+package org.folio.edge.patron.cache;
+
+import org.apache.log4j.Logger;
+import org.folio.edge.core.cache.Cache;
+import org.folio.edge.core.cache.Cache.Builder;
+import org.folio.edge.core.cache.Cache.CacheValue;
+
+public class PatronIdCache {
+
+  private static final Logger logger = Logger.getLogger(PatronIdCache.class);
+
+  private static PatronIdCache instance = null;
+
+  private Cache<String> cache;
+
+  private PatronIdCache(long ttl, long nullTokenTtl, int capacity) {
+    logger.info("Using TTL: " + ttl);
+    logger.info("Using null token TTL: " + nullTokenTtl);
+    logger.info("Using capcity: " + capacity);
+    cache = new Builder<String>()
+      .withTTL(ttl)
+      .withNullValueTTL(nullTokenTtl)
+      .withCapacity(capacity)
+      .build();
+  }
+
+  /**
+   * Get the PatronIdCache singleton. the singleton must be initialize before
+   * calling this method.
+   *
+   * @see {@link #initialize(long, int)}
+   *
+   * @return the PatronIdCache singleton instance.
+   */
+  public static synchronized PatronIdCache getInstance() {
+    if (instance == null) {
+      throw new NotInitializedException(
+          "You must call PatronIdCache.initialize(ttl, capacity) before you can get the singleton instance");
+    }
+    return instance;
+  }
+
+  /**
+   * Creates a new PatronIdCache instance, replacing the existing one if it
+   * already exists; in which case all pre-existing cache entries will be lost.
+   *
+   * @param ttl
+   *          cache entry time to live in ms
+   * @param capacity
+   *          maximum number of entries this cache will hold before pruning
+   * @return the new PatronIdCache singleton instance
+   */
+  public static synchronized PatronIdCache initialize(long ttl, long nullValueTtl, int capacity) {
+    if (instance != null) {
+      logger.warn("Reinitializing cache.  All cached entries will be lost");
+    }
+    instance = new PatronIdCache(ttl, nullValueTtl, capacity);
+    return instance;
+  }
+
+  public String get(String tenant, String externalId) {
+    return cache.get(computeKey(tenant, externalId));
+  }
+
+  public CacheValue<String> put(String tenant, String externalId, String internalId) {
+    return cache.put(computeKey(tenant, externalId), internalId);
+  }
+
+  private String computeKey(String tenant, String externalId) {
+    return String.format("%s:%s", tenant, externalId);
+  }
+
+  public static class NotInitializedException extends RuntimeException {
+
+    private static final long serialVersionUID = 4747532964596334577L;
+
+    public NotInitializedException(String msg) {
+      super(msg);
+    }
+  }
+
+}

--- a/src/main/java/org/folio/edge/patron/utils/PatronIdHelper.java
+++ b/src/main/java/org/folio/edge/patron/utils/PatronIdHelper.java
@@ -1,0 +1,44 @@
+package org.folio.edge.patron.utils;
+
+import java.util.concurrent.CompletableFuture;
+
+import org.apache.log4j.Logger;
+import org.folio.edge.core.cache.TokenCache.NotInitializedException;
+import org.folio.edge.patron.cache.PatronIdCache;
+
+public class PatronIdHelper {
+
+  private static final Logger logger = Logger.getLogger(PatronIdHelper.class);
+
+  private PatronIdHelper() {
+
+  }
+
+  public static CompletableFuture<String> lookupPatron(PatronOkapiClient client, String tenant, String extPatronId) {
+    CompletableFuture<String> future = new CompletableFuture<>();
+
+    String patronId = null;
+    try {
+      PatronIdCache cache = PatronIdCache.getInstance();
+      patronId = cache.get(tenant, extPatronId);
+    } catch (NotInitializedException e) {
+      logger.warn("Failed to access PatronIdCache", e);
+    }
+
+    if (patronId != null) {
+      logger.info("Using cached patronId");
+      future.complete(patronId);
+    } else {
+      client.getPatron(extPatronId).exceptionally(t -> {
+        logger.error("Patron lookup failed for " + extPatronId, t);
+        future.completeExceptionally(t);
+        return null;
+      }).thenAcceptAsync(internalId -> {
+        logger.info(String.format("Patron lookup successful: %s -> %s", extPatronId, internalId));
+        future.complete(internalId);
+      });
+    }
+    return future;
+  }
+
+}

--- a/src/test/java/org/folio/edge/patron/MainVerticleTest.java
+++ b/src/test/java/org/folio/edge/patron/MainVerticleTest.java
@@ -48,7 +48,8 @@ public class MainVerticleTest {
 
   private static final Logger logger = Logger.getLogger(MainVerticleTest.class);
 
-  private static final String patronId = UUID.randomUUID().toString();
+  private static final String extPatronId = PatronMockOkapi.extPatronId;
+  private static final String patronId = PatronMockOkapi.patronId;
   private static final String itemId = UUID.randomUUID().toString();
   private static final String instanceId = UUID.randomUUID().toString();
   private static final String holdId = UUID.randomUUID().toString();
@@ -125,7 +126,7 @@ public class MainVerticleTest {
     logger.info("=== Test getAccount with unknown apiKey (tenant) ===");
 
     final Response resp = RestAssured
-      .get(String.format("/patron/account/%s?apikey=%s", patronId, unknownTenantApiKey))
+      .get(String.format("/patron/account/%s?apikey=%s", extPatronId, unknownTenantApiKey))
       .then()
       .statusCode(401)
       .header(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN)
@@ -141,7 +142,7 @@ public class MainVerticleTest {
     logger.info("=== Test getAccount with malformed apiKey ===");
 
     final Response resp = RestAssured
-      .get(String.format("/patron/account/%s?apikey=%s", patronId, badApiKey))
+      .get(String.format("/patron/account/%s?apikey=%s", extPatronId, badApiKey))
       .then()
       .statusCode(401)
       .header(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN)
@@ -158,7 +159,7 @@ public class MainVerticleTest {
     logger.info("=== Test request where patron is found ===");
 
     final Response resp = RestAssured
-      .get(String.format("/patron/account/%s?apikey=%s", patronId, apiKey))
+      .get(String.format("/patron/account/%s?apikey=%s", extPatronId, apiKey))
       .then()
       .statusCode(200)
       .header(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON)
@@ -176,7 +177,7 @@ public class MainVerticleTest {
     logger.info("=== Test request where patron isn't found ===");
 
     final Response resp = RestAssured
-      .get(String.format("/patron/account/%s?apikey=%s", PatronMockOkapi.patronId_notFound, apiKey))
+      .get(String.format("/patron/account/%s?apikey=%s", PatronMockOkapi.extPatronId_notFound, apiKey))
       .then()
       .statusCode(404)
       .header(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN)
@@ -185,7 +186,7 @@ public class MainVerticleTest {
 
     String actual = resp.body().asString();
 
-    assertEquals(PatronMockOkapi.patronId_notFound + " not found", actual);
+    assertEquals("Unable to find patron " + PatronMockOkapi.extPatronId_notFound, actual);
   }
 
   @Test
@@ -339,7 +340,7 @@ public class MainVerticleTest {
 
     final Response resp = RestAssured
       .post(
-          String.format("/patron/account/%s/item/%s/renew?apikey=%s", PatronMockOkapi.patronId_notFound, itemId,
+          String.format("/patron/account/%s/item/%s/renew?apikey=%s", PatronMockOkapi.extPatronId_notFound, itemId,
               apiKey))
       .then()
       .statusCode(404)
@@ -347,7 +348,7 @@ public class MainVerticleTest {
       .extract()
       .response();
 
-    assertEquals(PatronMockOkapi.patronId_notFound + " not found", resp.body().asString());
+    assertEquals("Unable to find patron " + PatronMockOkapi.extPatronId_notFound, resp.body().asString());
   }
 
   @Test
@@ -356,7 +357,7 @@ public class MainVerticleTest {
 
     final Response resp = RestAssured
       .post(
-          String.format("/patron/account/%s/item/%s/renew?apikey=%s", patronId, PatronMockOkapi.itemId_notFound,
+          String.format("/patron/account/%s/item/%s/renew?apikey=%s", extPatronId, PatronMockOkapi.itemId_notFound,
               apiKey))
       .then()
       .statusCode(404)
@@ -450,15 +451,16 @@ public class MainVerticleTest {
       .body(hold.toJson())
       .contentType(APPLICATION_JSON)
       .post(
-          String.format("/patron/account/%s/instance/%s/hold?apikey=%s", PatronMockOkapi.patronId_notFound, instanceId,
+          String.format("/patron/account/%s/instance/%s/hold?apikey=%s", PatronMockOkapi.extPatronId_notFound,
+              instanceId,
               apiKey))
       .then()
-      .statusCode(501)
+      .statusCode(404)
       .header(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN)
       .extract()
       .response();
 
-    assertEquals(MSG_NOT_IMPLEMENTED, resp.body().asString());
+    assertEquals("Unable to find patron " + PatronMockOkapi.extPatronId_notFound, resp.body().asString());
   }
 
   @Test
@@ -571,17 +573,17 @@ public class MainVerticleTest {
 
     final Response resp = RestAssured
       .delete(
-          String.format("/patron/account/%s/instance/%s/hold/%s?apikey=%s", PatronMockOkapi.patronId_notFound,
+          String.format("/patron/account/%s/instance/%s/hold/%s?apikey=%s", PatronMockOkapi.extPatronId_notFound,
               instanceId,
               holdId,
               apiKey))
       .then()
-      .statusCode(501)
+      .statusCode(404)
       .header(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN)
       .extract()
       .response();
 
-    assertEquals(MSG_NOT_IMPLEMENTED, resp.body().asString());
+    assertEquals("Unable to find patron " + PatronMockOkapi.extPatronId_notFound, resp.body().asString());
   }
 
   @Test
@@ -837,14 +839,15 @@ public class MainVerticleTest {
       .body(hold.toJson())
       .contentType(APPLICATION_JSON)
       .post(
-          String.format("/patron/account/%s/item/%s/hold?apikey=%s", PatronMockOkapi.patronId_notFound, itemId, apiKey))
+          String.format("/patron/account/%s/item/%s/hold?apikey=%s", PatronMockOkapi.extPatronId_notFound, itemId,
+              apiKey))
       .then()
       .statusCode(404)
       .header(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN)
       .extract()
       .response();
 
-    assertEquals(PatronMockOkapi.patronId_notFound + " not found", resp.body().asString());
+    assertEquals("Unable to find patron " + PatronMockOkapi.extPatronId_notFound, resp.body().asString());
   }
 
   @Test
@@ -961,7 +964,7 @@ public class MainVerticleTest {
 
     final Response resp = RestAssured
       .delete(
-          String.format("/patron/account/%s/item/%s/hold/%s?apikey=%s", PatronMockOkapi.patronId_notFound, itemId,
+          String.format("/patron/account/%s/item/%s/hold/%s?apikey=%s", PatronMockOkapi.extPatronId_notFound, itemId,
               holdId,
               apiKey))
       .then()
@@ -970,7 +973,7 @@ public class MainVerticleTest {
       .extract()
       .response();
 
-    assertEquals(PatronMockOkapi.patronId_notFound + " not found", resp.body().asString());
+    assertEquals("Unable to find patron " + PatronMockOkapi.extPatronId_notFound, resp.body().asString());
   }
 
   @Test
@@ -979,7 +982,7 @@ public class MainVerticleTest {
 
     final Response resp = RestAssured
       .delete(
-          String.format("/patron/account/%s/item/%s/hold/%s?apikey=%s", patronId, PatronMockOkapi.itemId_notFound,
+          String.format("/patron/account/%s/item/%s/hold/%s?apikey=%s", extPatronId, PatronMockOkapi.itemId_notFound,
               holdId,
               apiKey))
       .then()
@@ -997,7 +1000,7 @@ public class MainVerticleTest {
 
     final Response resp = RestAssured
       .delete(
-          String.format("/patron/account/%s/item/%s/hold/%s?apikey=%s", patronId, itemId,
+          String.format("/patron/account/%s/item/%s/hold/%s?apikey=%s", extPatronId, itemId,
               PatronMockOkapi.holdReqId_notFound,
               apiKey))
       .then()
@@ -1015,7 +1018,8 @@ public class MainVerticleTest {
 
     final Response resp = RestAssured
       .delete(
-          String.format("/patron/account/%s/item/%s/hold/%s?apikey=%s", patronId, itemId, holdId, unknownTenantApiKey))
+          String.format("/patron/account/%s/item/%s/hold/%s?apikey=%s", extPatronId, itemId, holdId,
+              unknownTenantApiKey))
       .then()
       .statusCode(401)
       .header(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN)
@@ -1031,7 +1035,7 @@ public class MainVerticleTest {
     logger.info("=== Test remove item hold with malformed apiKey ===");
 
     final Response resp = RestAssured
-      .delete(String.format("/patron/account/%s/item/%s/hold/%s?apikey=%s", patronId, itemId, holdId, badApiKey))
+      .delete(String.format("/patron/account/%s/item/%s/hold/%s?apikey=%s", extPatronId, itemId, holdId, badApiKey))
       .then()
       .statusCode(401)
       .header(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN)
@@ -1050,7 +1054,7 @@ public class MainVerticleTest {
     final Response resp = RestAssured
       .with()
       .header(X_DURATION, requestTimeoutMs * 2)
-      .delete(String.format("/patron/account/%s/item/%s/hold/%s?apikey=%s", patronId, itemId, holdId,
+      .delete(String.format("/patron/account/%s/item/%s/hold/%s?apikey=%s", extPatronId, itemId, holdId,
           apiKey))
       .then()
       .contentType(TEXT_PLAIN)
@@ -1069,7 +1073,7 @@ public class MainVerticleTest {
 
     final Response resp = RestAssured
       .put(
-          String.format("/patron/account/%s/item/%s/hold/%s?apikey=%s", patronId, itemId, hold.requestId, apiKey))
+          String.format("/patron/account/%s/item/%s/hold/%s?apikey=%s", extPatronId, itemId, hold.requestId, apiKey))
       .then()
       .statusCode(501)
       .header(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN)
@@ -1085,7 +1089,7 @@ public class MainVerticleTest {
 
     final Response resp = RestAssured
       .delete(
-          String.format("/patron/account/%s/item/%s/hold/%s?apikey=%s", PatronMockOkapi.patronId_notFound, itemId,
+          String.format("/patron/account/%s/item/%s/hold/%s?apikey=%s", PatronMockOkapi.extPatronId_notFound, itemId,
               holdId,
               apiKey))
       .then()
@@ -1094,7 +1098,7 @@ public class MainVerticleTest {
       .extract()
       .response();
 
-    assertEquals(PatronMockOkapi.patronId_notFound + " not found", resp.body().asString());
+    assertEquals("Unable to find patron " + PatronMockOkapi.extPatronId_notFound, resp.body().asString());
   }
 
   @Test
@@ -1103,7 +1107,7 @@ public class MainVerticleTest {
 
     final Response resp = RestAssured
       .delete(
-          String.format("/patron/account/%s/item/%s/hold/%s?apikey=%s", patronId, PatronMockOkapi.itemId_notFound,
+          String.format("/patron/account/%s/item/%s/hold/%s?apikey=%s", extPatronId, PatronMockOkapi.itemId_notFound,
               holdId,
               apiKey))
       .then()
@@ -1121,7 +1125,7 @@ public class MainVerticleTest {
 
     final Response resp = RestAssured
       .delete(
-          String.format("/patron/account/%s/item/%s/hold/%s?apikey=%s", patronId, itemId,
+          String.format("/patron/account/%s/item/%s/hold/%s?apikey=%s", extPatronId, itemId,
               PatronMockOkapi.holdReqId_notFound,
               apiKey))
       .then()
@@ -1139,7 +1143,8 @@ public class MainVerticleTest {
 
     final Response resp = RestAssured
       .delete(
-          String.format("/patron/account/%s/item/%s/hold/%s?apikey=%s", patronId, itemId, holdId, unknownTenantApiKey))
+          String.format("/patron/account/%s/item/%s/hold/%s?apikey=%s", extPatronId, itemId, holdId,
+              unknownTenantApiKey))
       .then()
       .statusCode(401)
       .header(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN)
@@ -1155,7 +1160,7 @@ public class MainVerticleTest {
     logger.info("=== Test edit item hold with malformed apiKey ===");
 
     final Response resp = RestAssured
-      .delete(String.format("/patron/account/%s/item/%s/hold/%s?apikey=%s", patronId, itemId, holdId, badApiKey))
+      .delete(String.format("/patron/account/%s/item/%s/hold/%s?apikey=%s", extPatronId, itemId, holdId, badApiKey))
       .then()
       .statusCode(401)
       .header(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN)
@@ -1174,7 +1179,7 @@ public class MainVerticleTest {
     final Response resp = RestAssured
       .with()
       .header(X_DURATION, requestTimeoutMs * 2)
-      .delete(String.format("/patron/account/%s/item/%s/hold/%s?apikey=%s", patronId, itemId, holdId,
+      .delete(String.format("/patron/account/%s/item/%s/hold/%s?apikey=%s", extPatronId, itemId, holdId,
           apiKey))
       .then()
       .contentType(TEXT_PLAIN)
@@ -1194,7 +1199,7 @@ public class MainVerticleTest {
 
     for (int i = 0; i < iters; i++) {
       final Response resp = RestAssured
-        .get(String.format("/patron/account/%s?apikey=%s", patronId, apiKey))
+        .get(String.format("/patron/account/%s?apikey=%s", extPatronId, apiKey))
         .then()
         .contentType(APPLICATION_JSON)
         .statusCode(200)

--- a/src/test/java/org/folio/edge/patron/cache/PatronIdCacheTest.java
+++ b/src/test/java/org/folio/edge/patron/cache/PatronIdCacheTest.java
@@ -1,0 +1,163 @@
+package org.folio.edge.patron.cache;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.log4j.Logger;
+import org.folio.edge.core.cache.Cache.CacheValue;
+import org.junit.Before;
+import org.junit.Test;
+
+public class PatronIdCacheTest {
+
+  private static final Logger logger = Logger.getLogger(PatronIdCacheTest.class);
+
+  private static final int cap = 50;
+  private static final long ttl = 3000;
+  private static final long nullValueTtl = 1000;
+
+  private static final String tenant = "diku";
+  private static final String extPatronId = UUID.randomUUID().toString();
+  private static final String patronId = UUID.randomUUID().toString();
+
+  @Before
+  public void setUp() throws Exception {
+    // initialize singleton cache
+    PatronIdCache.initialize(ttl, nullValueTtl, cap);
+  }
+
+  @Test
+  public void testReinitialize() throws Exception {
+    logger.info("=== Test Reinitialize... ===");
+    final CacheValue<String> cached = PatronIdCache.getInstance().put(tenant, extPatronId, patronId);
+
+    await().with()
+      .pollInterval(20, TimeUnit.MILLISECONDS)
+      .atMost(ttl + 100, TimeUnit.MILLISECONDS)
+      .until(() -> cached.expired());
+
+    PatronIdCache.initialize(ttl * 2, nullValueTtl, cap);
+    final CacheValue<String> cached2 = PatronIdCache.getInstance().put(tenant, extPatronId, patronId);
+
+    await().with()
+      .pollInterval(20, TimeUnit.MILLISECONDS)
+      .atLeast(ttl, TimeUnit.MILLISECONDS)
+      .atMost(ttl * 2 + 100, TimeUnit.MILLISECONDS)
+      .until(() -> cached2.expired());
+  }
+
+  @Test
+  public void testEmpty() throws Exception {
+    logger.info("=== Test that a new cache is empty... ===");
+
+    // empty cache...
+    assertNull(PatronIdCache.getInstance().get(tenant, extPatronId));
+  }
+
+  @Test
+  public void testGetPutGet() throws Exception {
+    logger.info("=== Test basic functionality (Get, Put, Get)... ===");
+
+    PatronIdCache cache = PatronIdCache.getInstance();
+
+    // empty cache...
+    assertNull(cache.get(tenant, extPatronId));
+
+    // basic functionality
+    cache.put(tenant, extPatronId, patronId);
+    assertEquals(patronId, cache.get(tenant, extPatronId));
+  }
+
+  @Test
+  public void testNoOverwrite() throws Exception {
+    logger.info("=== Test entries aren't overwritten... ===");
+
+    PatronIdCache cache = PatronIdCache.getInstance();
+    String baseVal = "patronId";
+
+    // make sure we don't overwrite the cached patronIdue
+    cache.put(tenant, extPatronId, baseVal);
+    assertEquals(baseVal, cache.get(tenant, extPatronId));
+
+    for (int i = 0; i < 100; i++) {
+      cache.put(tenant, extPatronId, baseVal + i);
+      assertEquals(baseVal, cache.get(tenant, extPatronId));
+    }
+
+    // should expire very soon, if not already.
+    await().with()
+      .pollInterval(20, TimeUnit.MILLISECONDS)
+      .atMost(ttl + 100, TimeUnit.MILLISECONDS)
+      .until(() -> cache.get(tenant, extPatronId) == null);
+  }
+
+  @Test
+  public void testPruneExpires() throws Exception {
+    logger.info("=== Test pruning of expired entries... ===");
+
+    PatronIdCache cache = PatronIdCache.getInstance();
+    String baseVal = "patronId";
+
+    CacheValue<String> cached = cache.put(tenant, extPatronId + 0, baseVal);
+    await().with()
+      .pollInterval(20, TimeUnit.MILLISECONDS)
+      .atMost(ttl + 100, TimeUnit.MILLISECONDS)
+      .until(() -> cached.expired());
+
+    // load capacity + 1 entries triggering eviction of expired
+    for (int i = 1; i <= cap; i++) {
+      cache.put(tenant, extPatronId + i, baseVal + i);
+    }
+
+    // should be evicted as it's expired
+    assertNull(cache.get(tenant, extPatronId + 0));
+
+    // should still be cached
+    for (int i = 1; i <= cap; i++) {
+      assertEquals(baseVal + i, cache.get(tenant, extPatronId + i));
+    }
+  }
+
+  @Test
+  public void testPruneNoExpires() throws Exception {
+    logger.info("=== Test pruning of unexpired entries... ===");
+
+    PatronIdCache cache = PatronIdCache.getInstance();
+    String baseVal = "patronId";
+
+    // load capacity + 1 entries triggering eviction of the first
+    for (int i = 0; i <= cap; i++) {
+      cache.put(tenant, extPatronId + i, baseVal + i);
+    }
+
+    // should be evicted as it's the oldest
+    assertNull(cache.get(tenant, extPatronId + 0));
+
+    // should still be cached
+    for (int i = 1; i <= cap; i++) {
+      assertEquals(baseVal + i, cache.get(tenant, extPatronId + i));
+    }
+  }
+
+  @Test
+  public void testNullPatronIdExpires() throws Exception {
+    logger.info("=== Test expiration of null patronId entries... ===");
+
+    PatronIdCache cache = PatronIdCache.getInstance();
+
+    CacheValue<String> cached = cache.put(tenant, extPatronId, null);
+
+    assertNull(cache.get(tenant, extPatronId));
+
+    await().with()
+      .pollInterval(20, TimeUnit.MILLISECONDS)
+      .atMost(nullValueTtl + 100, TimeUnit.MILLISECONDS)
+      .until(() -> cached.expired());
+
+    assertNull(cache.get(tenant, extPatronId));
+  }
+}

--- a/src/test/java/org/folio/edge/patron/utils/PatronMockOkapi.java
+++ b/src/test/java/org/folio/edge/patron/utils/PatronMockOkapi.java
@@ -113,7 +113,7 @@ public class PatronMockOkapi extends MockOkapi {
       ctx.response()
         .setStatusCode(403)
         .putHeader(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN)
-        .end("Access requires permission: users.item.get");
+        .end("Access requires permission: users.collection.get");
     } else {
       String[] parts = query.split("==");
       String extPatronId = parts[1];

--- a/src/test/java/org/folio/edge/patron/utils/PatronOkapiClientTest.java
+++ b/src/test/java/org/folio/edge/patron/utils/PatronOkapiClientTest.java
@@ -82,6 +82,21 @@ public class PatronOkapiClientTest {
   }
 
   @Test
+  public void testGetPatronInsufficientPrivs(TestContext context) throws Exception {
+    logger.info("=== Test getPatron patron doesn't exist ===");
+
+    try {
+      client.getPatron(PatronMockOkapi.extPatronId).get();
+      fail("Expected " + PatronLookupException.class.getName() + " to be thrown");
+    } catch (Exception e) {
+      if (!(e.getCause() instanceof PatronLookupException)) {
+        fail("Expected " + PatronLookupException.class.getName() + " got " + e.getCause().getClass().getName());
+        throw e;
+      }
+    }
+  }
+
+  @Test
   public void testGetAccountWithAll(TestContext context) throws Exception {
     logger.info("=== Test successful getAccount request w/ all data ===");
 

--- a/src/test/java/org/folio/edge/patron/utils/PatronOkapiClientTest.java
+++ b/src/test/java/org/folio/edge/patron/utils/PatronOkapiClientTest.java
@@ -2,6 +2,7 @@ package org.folio.edge.patron.utils;
 
 import static org.folio.edge.core.utils.test.MockOkapi.MOCK_TOKEN;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -10,6 +11,7 @@ import java.util.UUID;
 import org.apache.log4j.Logger;
 import org.folio.edge.core.utils.test.TestUtils;
 import org.folio.edge.patron.model.Hold;
+import org.folio.edge.patron.utils.PatronOkapiClient.PatronLookupException;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -50,6 +52,33 @@ public class PatronOkapiClientTest {
   @After
   public void tearDown(TestContext context) {
     mockOkapi.close();
+  }
+
+  @Test
+  public void testGetPatronExistent(TestContext context) throws Exception {
+    logger.info("=== Test getPatron exists ===");
+
+    client.login("admin", "password").get();
+    assertEquals(MOCK_TOKEN, client.getToken());
+    String patronId = client.getPatron(PatronMockOkapi.extPatronId).get();
+    assertEquals(PatronMockOkapi.patronId, patronId);
+  }
+
+  @Test
+  public void testGetPatronNonExistentPatron(TestContext context) throws Exception {
+    logger.info("=== Test getPatron patron doesn't exist ===");
+
+    client.login("admin", "password").get();
+    assertEquals(MOCK_TOKEN, client.getToken());
+    try {
+      client.getPatron(PatronMockOkapi.extPatronId_notFound).get();
+      fail("Expected " + PatronLookupException.class.getName() + " to be thrown");
+    } catch (Exception e) {
+      if (!(e.getCause() instanceof PatronLookupException)) {
+        fail("Expected " + PatronLookupException.class.getName() + " got " + e.getCause().getClass().getName());
+        throw e;
+      }
+    }
   }
 
   @Test


### PR DESCRIPTION
It's unrealistic to think that existing users in an SSO IdP will have the same patron/user ID that's used within FOLIO.  As such, it's necessary to perform some mapping of external ID to internal ID.  The solution implemented uses the 'externalSystemId' field for this purpose.

- mod-users is queried using the provided (external patron ID)
- the external -> internal ID mapping is cached for a configurable amount of time
- once an internal ID is obtained, it's used for all subsequent calls into mod-patron