### PR TITLE
refactor code to resolve timing issue

### DIFF
--- a/src/main/java/org/folio/edge/patron/utils/PatronIdHelper.java
+++ b/src/main/java/org/folio/edge/patron/utils/PatronIdHelper.java
@@ -29,13 +29,13 @@ public class PatronIdHelper {
       logger.info("Using cached patronId");
       future.complete(patronId);
     } else {
-      client.getPatron(extPatronId).exceptionally(t -> {
+      client.getPatron(extPatronId).thenAcceptAsync(internalId -> {
+        logger.info(String.format("Patron lookup successful: %s -> %s", extPatronId, internalId));
+        future.complete(internalId);
+      }).exceptionally(t -> {
         logger.error("Patron lookup failed for " + extPatronId, t);
         future.completeExceptionally(t);
         return null;
-      }).thenAcceptAsync(internalId -> {
-        logger.info(String.format("Patron lookup successful: %s -> %s", extPatronId, internalId));
-        future.complete(internalId);
       });
     }
     return future;


### PR DESCRIPTION
There were some transient JUnit test failures that I traced back to an issue in the code how the  asynchronous exception handling was defined.  Apparently, if an exception was thrown from a particular part of the code, exception handling and happy path code would wind up running in parallel, creating a race condition.  Depending on how fast the exception handling code ran, this sometimes resulted in the expected behavior, and sometimes in unexpected behavior.  

The problem was resolved by refactoring how these handlers were defined; more specifically the order in which they are defined.