### PR TITLE
Handle no resp body

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>edge-patron</artifactId>
-  <version>0.1.3-SNAPSHOT</version>
+  <version>0.1.4-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Edge API - Patron Empowerment</name>

--- a/src/main/java/org/folio/edge/patron/PatronHandler.java
+++ b/src/main/java/org/folio/edge/patron/PatronHandler.java
@@ -228,10 +228,20 @@ public class PatronHandler {
   }
 
   private void handleProxyResponse(RoutingContext ctx, HttpClientResponse resp) {
-    resp.bodyHandler(body -> ctx.response()
-      .setStatusCode(resp.statusCode())
-      .putHeader(HttpHeaders.CONTENT_TYPE, resp.getHeader(HttpHeaders.CONTENT_TYPE))
-      .end(body.toString()));
+    final StringBuilder body = new StringBuilder();
+    resp.handler(buf -> {
+      logger.debug("read Bytes: " + buf.toString());
+      body.append(buf);
+    }).endHandler(v -> {
+      ctx.response().setStatusCode(resp.statusCode());
+
+      String contentType = resp.getHeader(HttpHeaders.CONTENT_TYPE);
+      if (contentType != null) {
+        ctx.response().putHeader(HttpHeaders.CONTENT_TYPE, contentType);
+      }
+
+      ctx.response().end(body.toString());
+    });
   }
 
   private void handleProxyException(RoutingContext ctx, Throwable t) {

--- a/src/test/java/org/folio/edge/patron/MainVerticleTest.java
+++ b/src/test/java/org/folio/edge/patron/MainVerticleTest.java
@@ -9,7 +9,6 @@ import static org.folio.edge.core.Constants.SYS_SECURE_STORE_PROP_FILE;
 import static org.folio.edge.core.Constants.TEXT_PLAIN;
 import static org.folio.edge.core.utils.test.MockOkapi.X_DURATION;
 import static org.folio.edge.patron.Constants.MSG_ACCESS_DENIED;
-import static org.folio.edge.patron.Constants.MSG_NOT_IMPLEMENTED;
 import static org.folio.edge.patron.Constants.MSG_REQUEST_TIMEOUT;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -433,11 +432,10 @@ public class MainVerticleTest {
           String.format("/patron/account/%s/instance/%s/hold?apikey=%s", patronId, instanceId, apiKey))
       .then()
       .statusCode(501)
-      .header(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN)
       .extract()
       .response();
 
-    assertEquals(MSG_NOT_IMPLEMENTED, resp.getBody().asString());
+    assertEquals("", resp.getBody().asString());
   }
 
   @Test
@@ -478,11 +476,10 @@ public class MainVerticleTest {
               apiKey))
       .then()
       .statusCode(501)
-      .header(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN)
       .extract()
       .response();
 
-    assertEquals(MSG_NOT_IMPLEMENTED, resp.body().asString());
+    assertEquals("", resp.body().asString());
   }
 
   @Test
@@ -560,11 +557,10 @@ public class MainVerticleTest {
           String.format("/patron/account/%s/instance/%s/hold/%s?apikey=%s", patronId, instanceId, holdId, apiKey))
       .then()
       .statusCode(501)
-      .header(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN)
       .extract()
       .response();
 
-    assertEquals(MSG_NOT_IMPLEMENTED, resp.getBody().asString());
+    assertEquals("", resp.getBody().asString());
   }
 
   @Test
@@ -598,11 +594,10 @@ public class MainVerticleTest {
               apiKey))
       .then()
       .statusCode(501)
-      .header(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN)
       .extract()
       .response();
 
-    assertEquals(MSG_NOT_IMPLEMENTED, resp.body().asString());
+    assertEquals("", resp.body().asString());
   }
 
   @Test
@@ -616,11 +611,10 @@ public class MainVerticleTest {
               apiKey))
       .then()
       .statusCode(501)
-      .header(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN)
       .extract()
       .response();
 
-    assertEquals(MSG_NOT_IMPLEMENTED, resp.body().asString());
+    assertEquals("", resp.body().asString());
   }
 
   @Test
@@ -688,11 +682,10 @@ public class MainVerticleTest {
               apiKey))
       .then()
       .statusCode(501)
-      .header(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN)
       .extract()
       .response();
 
-    assertEquals(MSG_NOT_IMPLEMENTED, resp.getBody().asString());
+    assertEquals("", resp.getBody().asString());
   }
 
   @Test
@@ -707,11 +700,10 @@ public class MainVerticleTest {
               apiKey))
       .then()
       .statusCode(501)
-      .header(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN)
       .extract()
       .response();
 
-    assertEquals(MSG_NOT_IMPLEMENTED, resp.body().asString());
+    assertEquals("", resp.body().asString());
   }
 
   @Test
@@ -726,11 +718,10 @@ public class MainVerticleTest {
               apiKey))
       .then()
       .statusCode(501)
-      .header(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN)
       .extract()
       .response();
 
-    assertEquals(MSG_NOT_IMPLEMENTED, resp.body().asString());
+    assertEquals("", resp.body().asString());
   }
 
   @Test
@@ -744,11 +735,10 @@ public class MainVerticleTest {
               apiKey))
       .then()
       .statusCode(501)
-      .header(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN)
       .extract()
       .response();
 
-    assertEquals(MSG_NOT_IMPLEMENTED, resp.body().asString());
+    assertEquals("", resp.body().asString());
   }
 
   @Test
@@ -1076,11 +1066,10 @@ public class MainVerticleTest {
           String.format("/patron/account/%s/item/%s/hold/%s?apikey=%s", extPatronId, itemId, hold.requestId, apiKey))
       .then()
       .statusCode(501)
-      .header(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN)
       .extract()
       .response();
 
-    assertEquals(MSG_NOT_IMPLEMENTED, resp.getBody().asString());
+    assertEquals("", resp.getBody().asString());
   }
 
   @Test

--- a/src/test/java/org/folio/edge/patron/utils/PatronMockOkapi.java
+++ b/src/test/java/org/folio/edge/patron/utils/PatronMockOkapi.java
@@ -4,7 +4,6 @@ import static org.folio.edge.core.Constants.APPLICATION_JSON;
 import static org.folio.edge.core.Constants.DAY_IN_MILLIS;
 import static org.folio.edge.core.Constants.TEXT_PLAIN;
 import static org.folio.edge.core.Constants.X_OKAPI_TOKEN;
-import static org.folio.edge.patron.Constants.MSG_NOT_IMPLEMENTED;
 import static org.folio.edge.patron.Constants.PARAM_HOLD_ID;
 import static org.folio.edge.patron.Constants.PARAM_INCLUDE_CHARGES;
 import static org.folio.edge.patron.Constants.PARAM_INCLUDE_HOLDS;
@@ -238,8 +237,7 @@ public class PatronMockOkapi extends MockOkapi {
   public void editItemHoldHandler(RoutingContext ctx) {
     ctx.response()
       .setStatusCode(501)
-      .putHeader(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN)
-      .end(MSG_NOT_IMPLEMENTED);
+      .end();
   }
 
   public void removeItemHoldHandler(RoutingContext ctx) {
@@ -285,22 +283,19 @@ public class PatronMockOkapi extends MockOkapi {
   public void placeInstanceHoldHandler(RoutingContext ctx) {
     ctx.response()
       .setStatusCode(501)
-      .putHeader(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN)
-      .end(MSG_NOT_IMPLEMENTED);
+      .end();
   }
 
   public void editInstanceHoldHandler(RoutingContext ctx) {
     ctx.response()
       .setStatusCode(501)
-      .putHeader(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN)
-      .end(MSG_NOT_IMPLEMENTED);
+      .end();
   }
 
   public void removeInstanceHoldHandler(RoutingContext ctx) {
     ctx.response()
       .setStatusCode(501)
-      .putHeader(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN)
-      .end(MSG_NOT_IMPLEMENTED);
+      .end();
   }
 
   public static String getPatronJson(String extPatronId) {


### PR DESCRIPTION
Since PatronHandler was only setting a "bodyHandler" for responses, if there was not body, the request to edge-patron wouldn't complete until it timed out.

The solution was to use a combination of a standard "handler" and "endHandler".

Note that I think part of the cause of this is how vertx handles responses with a content-type, but no body.  In the case of the 501 (not implemented) responses coming from mod-patron, neither were present, though both were in the unit tests, which have now been updated accordingly.