### PR TITLE
Error msg wrapper

### DIFF
--- a/src/main/java/org/folio/edge/patron/PatronHandler.java
+++ b/src/main/java/org/folio/edge/patron/PatronHandler.java
@@ -289,7 +289,7 @@ public class PatronHandler extends Handler {
       Errors err  =  Json.decodeValue(respBody, Errors.class);
       List<Error> errors = err.getErrors();
 
-      if (errors != null && errors.size() > 0) {
+      if (errors != null && !errors.isEmpty()) {
         Error firstErrorInstance = errors.get(0);  //get the first error message and return it.
         if (firstErrorInstance != null) {
           errorMessage = getStructuredErrorMessage(statusCode, firstErrorInstance.getMessage());

--- a/src/main/java/org/folio/edge/patron/model/ErrorMessage.java
+++ b/src/main/java/org/folio/edge/patron/model/ErrorMessage.java
@@ -13,7 +13,7 @@ import java.io.IOException;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JacksonXmlRootElement(localName = "error")
-@JsonDeserialize(builder = Item.Builder.class)
+@JsonDeserialize(builder = ErrorMessage.Builder.class)
 @JsonPropertyOrder({
         "code",
         "message"
@@ -76,7 +76,33 @@ public class ErrorMessage {
         return Mappers.jsonMapper.readValue(json, ErrorMessage.class);
     }
 
-    public static ErrorMessage fromXml(String xml) throws IOException {
+    public static ErrorMessage fromXml(String xml) throws IOException{
         return Mappers.xmlMapper.readValue(xml, ErrorMessage.class);
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static class Builder {
+
+        private Integer httpStatusCode;
+        private String errorMessage;
+
+        @JsonProperty("code")
+        public Builder item(Integer httpStatusCode) {
+            this.httpStatusCode = httpStatusCode;
+            return this;
+        }
+
+        @JsonProperty("message")
+        public Builder chargeAmount(String errorMessage) {
+            this.errorMessage = errorMessage;
+            return this;
+        }
+
+        public ErrorMessage build() {
+            return new ErrorMessage(httpStatusCode, errorMessage);
+        }
     }
 }

--- a/src/main/java/org/folio/edge/patron/model/ErrorMessage.java
+++ b/src/main/java/org/folio/edge/patron/model/ErrorMessage.java
@@ -1,0 +1,82 @@
+package org.folio.edge.patron.model;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+import org.folio.edge.core.utils.Mappers;
+
+import javax.annotation.Generated;
+import java.io.IOException;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JacksonXmlRootElement(localName = "error")
+@JsonDeserialize(builder = Item.Builder.class)
+@JsonPropertyOrder({
+        "code",
+        "message"
+})
+public class ErrorMessage {
+
+    @JsonProperty("code")
+    public final Integer httpStatusCode;
+
+    @JsonProperty("message")
+    public final String errorMessage;
+
+    public ErrorMessage(int statusCode, String errorMsg){
+        this.httpStatusCode = statusCode;
+        this.errorMessage = errorMsg;
+    }
+
+    @Override
+    @Generated("Eclipse")
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (!(obj instanceof ErrorMessage)) {
+            return false;
+        }
+        ErrorMessage other = (ErrorMessage) obj;
+
+        if (this.httpStatusCode == null) {
+            if (other.httpStatusCode != null) {
+                return false;
+            }
+        } else if (!httpStatusCode.equals(other.httpStatusCode)) {
+            return false;
+        }
+
+        if (this.errorMessage == null) {
+            if (other.errorMessage != null) {
+                return false;
+            }
+        } else if (!errorMessage.equals(other.errorMessage)) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public String toXml() throws JsonProcessingException {
+        return Mappers.XML_PROLOG + Mappers.xmlMapper.writeValueAsString(this);
+    }
+
+    public String toJson() throws JsonProcessingException {
+        return Mappers.jsonMapper.writeValueAsString(this);
+    }
+
+    public static ErrorMessage fromJson(String json) throws IOException {
+        return Mappers.jsonMapper.readValue(json, ErrorMessage.class);
+    }
+
+    public static ErrorMessage fromXml(String xml) throws IOException {
+        return Mappers.xmlMapper.readValue(xml, ErrorMessage.class);
+    }
+}

--- a/src/main/java/org/folio/edge/patron/model/error/Error.java
+++ b/src/main/java/org/folio/edge/patron/model/error/Error.java
@@ -7,11 +7,12 @@ import java.util.Map;
 import javax.annotation.Generated;
 
 import com.fasterxml.jackson.annotation.*;
+import jdk.nashorn.internal.ir.annotations.Ignore;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Generated("org.jsonschema2pojo")
 @JsonPropertyOrder({ "message", "type", "code", "parameters" })
-public class Error {
+public class Error {  //NOSONAR
 
     /**
      *
@@ -19,7 +20,7 @@ public class Error {
      *
      */
     @JsonProperty("message")
-    private String message;
+    private String message;  //NOSONAR
 
     @JsonProperty("type")
     private String type;

--- a/src/main/java/org/folio/edge/patron/model/error/Error.java
+++ b/src/main/java/org/folio/edge/patron/model/error/Error.java
@@ -7,12 +7,11 @@ import java.util.Map;
 import javax.annotation.Generated;
 
 import com.fasterxml.jackson.annotation.*;
-import jdk.nashorn.internal.ir.annotations.Ignore;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Generated("org.jsonschema2pojo")
 @JsonPropertyOrder({ "message", "type", "code", "parameters" })
-public class Error {  //NOSONAR
+public class Error {
 
     /**
      *
@@ -20,7 +19,7 @@ public class Error {  //NOSONAR
      *
      */
     @JsonProperty("message")
-    private String message;  //NOSONAR
+    private String message;
 
     @JsonProperty("type")
     private String type;

--- a/src/main/java/org/folio/edge/patron/model/error/Error.java
+++ b/src/main/java/org/folio/edge/patron/model/error/Error.java
@@ -1,0 +1,154 @@
+package org.folio.edge.patron.model.error;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Generated;
+
+import com.fasterxml.jackson.annotation.*;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("org.jsonschema2pojo")
+@JsonPropertyOrder({ "message", "type", "code", "parameters" })
+public class Error {
+
+    /**
+     *
+     * (Required)
+     *
+     */
+    @JsonProperty("message")
+    private String message;
+
+    @JsonProperty("type")
+    private String type;
+
+    @JsonProperty("code")
+    private String code;
+
+    @JsonProperty("parameters")
+    private List<Parameter> parameters = new ArrayList<Parameter>();
+
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    /**
+     *
+     * (Required)
+     *
+     * @return
+     *     The message
+     */
+    @JsonProperty("message")
+    public String getMessage() {
+        return message;
+    }
+
+    /**
+     *
+     * (Required)
+     *
+     * @param message
+     *     The message
+     */
+    @JsonProperty("message")
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public Error withMessage(String message) {
+        this.message = message;
+        return this;
+    }
+
+    /**
+     *
+     * @return
+     *     The type
+     */
+    @JsonProperty("type")
+    public String getType() {
+        return type;
+    }
+
+    /**
+     *
+     * @param type
+     *     The type
+     */
+    @JsonProperty("type")
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public Error withType(String type) {
+        this.type = type;
+        return this;
+    }
+
+    /**
+     *
+     * @return
+     *     The code
+     */
+    @JsonProperty("code")
+    public String getCode() {
+        return code;
+    }
+
+    /**
+     *
+     * @param code
+     *     The code
+     */
+    @JsonProperty("code")
+    public void setCode(String code) {
+        this.code = code;
+    }
+
+    public Error withCode(String code) {
+        this.code = code;
+        return this;
+    }
+
+    /**
+     *
+     * @return
+     *     The parameters
+     */
+    @JsonProperty("parameters")
+    public List<Parameter> getParameters() {
+        return parameters;
+    }
+
+    /**
+     *
+     * @param parameters
+     *     The parameters
+     */
+    @JsonProperty("parameters")
+    public void setParameters(List<Parameter> parameters) {
+        this.parameters = parameters;
+    }
+
+    public Error withParameters(List<Parameter> parameters) {
+        this.parameters = parameters;
+        return this;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    public Error withAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+        return this;
+    }
+}

--- a/src/main/java/org/folio/edge/patron/model/error/ErrorMessage.java
+++ b/src/main/java/org/folio/edge/patron/model/error/ErrorMessage.java
@@ -21,7 +21,7 @@ import java.io.IOException;
 public class ErrorMessage {
 
     @JsonProperty("code")
-    public final Integer httpStatusCode;
+    public final int httpStatusCode;
 
     @JsonProperty("message")
     public final String message;
@@ -45,13 +45,8 @@ public class ErrorMessage {
         }
         ErrorMessage other = (ErrorMessage) obj;
 
-        if (this.httpStatusCode == null) {
-            if (other.httpStatusCode != null) {
-                return false;
-            }
-        } else if (!httpStatusCode.equals(other.httpStatusCode)) {
+        if (httpStatusCode != other.httpStatusCode)
             return false;
-        }
 
         if (this.message == null) {
             if (other.message != null) {

--- a/src/main/java/org/folio/edge/patron/model/error/ErrorMessage.java
+++ b/src/main/java/org/folio/edge/patron/model/error/ErrorMessage.java
@@ -1,4 +1,4 @@
-package org.folio.edge.patron.model;
+package org.folio.edge.patron.model.error;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;

--- a/src/main/java/org/folio/edge/patron/model/error/ErrorMessage.java
+++ b/src/main/java/org/folio/edge/patron/model/error/ErrorMessage.java
@@ -24,11 +24,11 @@ public class ErrorMessage {
     public final Integer httpStatusCode;
 
     @JsonProperty("message")
-    public final String errorMessage;
+    public final String message;
 
     public ErrorMessage(int statusCode, String errorMsg){
         this.httpStatusCode = statusCode;
-        this.errorMessage = errorMsg;
+        this.message = errorMsg;
     }
 
     @Override
@@ -53,11 +53,11 @@ public class ErrorMessage {
             return false;
         }
 
-        if (this.errorMessage == null) {
-            if (other.errorMessage != null) {
+        if (this.message == null) {
+            if (other.message != null) {
                 return false;
             }
-        } else if (!errorMessage.equals(other.errorMessage)) {
+        } else if (!message.equals(other.message)) {
             return false;
         }
 
@@ -87,7 +87,7 @@ public class ErrorMessage {
     public static class Builder {
 
         private Integer httpStatusCode;
-        private String errorMessage;
+        private String message;
 
         @JsonProperty("code")
         public Builder item(Integer httpStatusCode) {
@@ -97,12 +97,12 @@ public class ErrorMessage {
 
         @JsonProperty("message")
         public Builder chargeAmount(String errorMessage) {
-            this.errorMessage = errorMessage;
+            this.message = errorMessage;
             return this;
         }
 
         public ErrorMessage build() {
-            return new ErrorMessage(httpStatusCode, errorMessage);
+            return new ErrorMessage(httpStatusCode, message);
         }
     }
 }

--- a/src/main/java/org/folio/edge/patron/model/error/Errors.java
+++ b/src/main/java/org/folio/edge/patron/model/error/Errors.java
@@ -15,7 +15,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Generated("org.jsonschema2pojo")
 @JsonPropertyOrder({ "errors", "total_records" })
-public class Errors {
+public class Errors {  //NOSONAR
 
     @JsonProperty("errors")
     private List<Error> errors = new ArrayList<Error>();

--- a/src/main/java/org/folio/edge/patron/model/error/Errors.java
+++ b/src/main/java/org/folio/edge/patron/model/error/Errors.java
@@ -1,0 +1,93 @@
+package org.folio.edge.patron.model.error;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("org.jsonschema2pojo")
+@JsonPropertyOrder({ "errors", "total_records" })
+public class Errors {
+
+    @JsonProperty("errors")
+    private List<Error> errors = new ArrayList<Error>();
+
+    @JsonProperty("total_records")
+    private Integer totalRecords;
+
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    /**
+     *
+     * @return
+     *     The errors
+     */
+    @JsonProperty("errors")
+    public List<Error> getErrors() {
+        return errors;
+    }
+
+    /**
+     *
+     * @param errors
+     *     The errors
+     */
+    @JsonProperty("errors")
+    public void setErrors(List<Error> errors) {
+        this.errors = errors;
+    }
+
+    public Errors withErrors(List<Error> errors) {
+        this.errors = errors;
+        return this;
+    }
+
+    /**
+     *
+     * @return
+     *     The totalRecords
+     */
+    @JsonProperty("total_records")
+    public Integer getTotalRecords() {
+        return totalRecords;
+    }
+
+    /**
+     *
+     * @param totalRecords
+     *     The total_records
+     */
+    @JsonProperty("total_records")
+    public void setTotalRecords(Integer totalRecords) {
+        this.totalRecords = totalRecords;
+    }
+
+    public Errors withTotalRecords(Integer totalRecords) {
+        this.totalRecords = totalRecords;
+        return this;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    public Errors withAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+        return this;
+    }
+}

--- a/src/main/java/org/folio/edge/patron/model/error/Parameter.java
+++ b/src/main/java/org/folio/edge/patron/model/error/Parameter.java
@@ -14,7 +14,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Generated("org.jsonschema2pojo")
 @JsonPropertyOrder({ "key", "value" })
-public class Parameter { //NOSONAR
+public class Parameter {
 
     @JsonProperty("key")
     private String key;

--- a/src/main/java/org/folio/edge/patron/model/error/Parameter.java
+++ b/src/main/java/org/folio/edge/patron/model/error/Parameter.java
@@ -14,7 +14,7 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @Generated("org.jsonschema2pojo")
 @JsonPropertyOrder({ "key", "value" })
-public class Parameter {
+public class Parameter { //NOSONAR
 
     @JsonProperty("key")
     private String key;

--- a/src/main/java/org/folio/edge/patron/model/error/Parameter.java
+++ b/src/main/java/org/folio/edge/patron/model/error/Parameter.java
@@ -1,0 +1,92 @@
+package org.folio.edge.patron.model.error;
+
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("org.jsonschema2pojo")
+@JsonPropertyOrder({ "key", "value" })
+public class Parameter {
+
+    @JsonProperty("key")
+    private String key;
+
+    @JsonProperty("value")
+    private String value;
+
+    @JsonIgnore
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    /**
+     *
+     * @return
+     *     The key
+     */
+    @JsonProperty("key")
+    public String getKey() {
+        return key;
+    }
+
+    /**
+     *
+     * @param key
+     *     The key
+     */
+    @JsonProperty("key")
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public Parameter withKey(String key) {
+        this.key = key;
+        return this;
+    }
+
+    /**
+     *
+     * @return
+     *     The value
+     */
+    @JsonProperty("value")
+    public String getValue() {
+        return value;
+    }
+
+    /**
+     *
+     * @param value
+     *     The value
+     */
+    @JsonProperty("value")
+    public void setValue(String value) {
+        this.value = value;
+    }
+
+    public Parameter withValue(String value) {
+        this.value = value;
+        return this;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    public Parameter withAdditionalProperty(String name, Object value) {
+        this.additionalProperties.put(name, value);
+        return this;
+    }
+}

--- a/src/test/java/org/folio/edge/patron/MainVerticleTest.java
+++ b/src/test/java/org/folio/edge/patron/MainVerticleTest.java
@@ -138,8 +138,8 @@ public class MainVerticleTest {
       .response();
 
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
-    assertEquals(MSG_ACCESS_DENIED, msg.errorMessage);
-    assertEquals(expectedStatusCode, (long)msg.httpStatusCode);
+    assertEquals(MSG_ACCESS_DENIED, msg.message);
+    assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
   }
 
   @Test
@@ -158,8 +158,8 @@ public class MainVerticleTest {
 
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
 
-    assertEquals(MSG_ACCESS_DENIED, msg.errorMessage);
-    assertEquals(expectedStatusCode, (long)msg.httpStatusCode);
+    assertEquals(MSG_ACCESS_DENIED, msg.message);
+    assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
   }
 
   @Test
@@ -196,8 +196,8 @@ public class MainVerticleTest {
 
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
 
-    assertEquals("Unable to find patron " + PatronMockOkapi.extPatronId_notFound, msg.errorMessage);
-    assertEquals(expectedStatusCode, (long)msg.httpStatusCode);
+    assertEquals("Unable to find patron " + PatronMockOkapi.extPatronId_notFound, msg.message);
+    assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
   }
 
   @Test
@@ -216,8 +216,8 @@ public class MainVerticleTest {
 
       ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
 
-    assertEquals(MSG_ACCESS_DENIED, msg.errorMessage);
-    assertEquals(expectedStatusCode, (long)msg.httpStatusCode);
+    assertEquals(MSG_ACCESS_DENIED, msg.message);
+    assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
   }
 
   @Test
@@ -330,8 +330,8 @@ public class MainVerticleTest {
 
       ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
 
-      assertEquals(MSG_REQUEST_TIMEOUT, msg.errorMessage);
-      assertEquals(expectedStatusCode, (long)msg.httpStatusCode);
+      assertEquals(MSG_REQUEST_TIMEOUT, msg.message);
+      assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
   }
 
   @Test
@@ -370,8 +370,8 @@ public class MainVerticleTest {
       .response();
 
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
-    assertEquals("Unable to find patron " + PatronMockOkapi.extPatronId_notFound, msg.errorMessage);
-    assertEquals(expectedStatusCode, (long)msg.httpStatusCode);
+    assertEquals("Unable to find patron " + PatronMockOkapi.extPatronId_notFound, msg.message);
+    assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
   }
 
   @Test
@@ -391,8 +391,8 @@ public class MainVerticleTest {
       .response();
 
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
-    assertEquals(PatronMockOkapi.itemId_notFound + " not found", msg.errorMessage);
-    assertEquals(expectedStatusCode, (long) msg.httpStatusCode);
+    assertEquals(PatronMockOkapi.itemId_notFound + " not found", msg.message);
+    assertEquals(expectedStatusCode, (int) msg.httpStatusCode);
   }
 
   @Test
@@ -411,8 +411,8 @@ public class MainVerticleTest {
 
       ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
 
-    assertEquals(MSG_ACCESS_DENIED, msg.errorMessage);
-    assertEquals(expectedStatusCode, (long)msg.httpStatusCode);
+    assertEquals(MSG_ACCESS_DENIED, msg.message);
+    assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
   }
 
   @Test
@@ -429,8 +429,8 @@ public class MainVerticleTest {
 
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
 
-    assertEquals(MSG_ACCESS_DENIED, msg.errorMessage);
-    assertEquals(401, (long)msg.httpStatusCode);
+    assertEquals(MSG_ACCESS_DENIED, msg.message);
+    assertEquals(401, (int)msg.httpStatusCode);
   }
 
   @Test
@@ -452,8 +452,8 @@ public class MainVerticleTest {
 
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
 
-    assertEquals(MSG_REQUEST_TIMEOUT, msg.errorMessage);
-    assertEquals(expectedStatusCode, (long)msg.httpStatusCode);
+    assertEquals(MSG_REQUEST_TIMEOUT, msg.message);
+    assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
   }
 
     @Test
@@ -474,8 +474,8 @@ public class MainVerticleTest {
 
         ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
 
-        assertEquals("loan has reached its maximum number of renewals", msg.errorMessage);
-        assertEquals(expectedStatusCode, (long)msg.httpStatusCode);
+        assertEquals("loan has reached its maximum number of renewals", msg.message);
+        assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
     }
 
     @Test
@@ -496,8 +496,8 @@ public class MainVerticleTest {
 
         ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
 
-        assertEquals("No error message found", msg.errorMessage);
-        assertEquals(expectedStatusCode, (long)msg.httpStatusCode);
+        assertEquals("No error message found", msg.message);
+        assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
     }
 
     @Test
@@ -518,8 +518,8 @@ public class MainVerticleTest {
 
         ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
 
-        assertEquals("A problem encountered when extracting error message", msg.errorMessage);
-        assertEquals(expectedStatusCode, (long)msg.httpStatusCode);
+        assertEquals("A problem encountered when extracting error message", msg.message);
+        assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
     }
 
   @Test
@@ -542,8 +542,8 @@ public class MainVerticleTest {
       .response();
 
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
-    assertEquals("", msg.errorMessage);
-    assertEquals(expectedStatusCode, (long)msg.httpStatusCode);
+    assertEquals("", msg.message);
+    assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
   }
 
   @Test
@@ -568,8 +568,8 @@ public class MainVerticleTest {
       .response();
 
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
-    assertEquals("Unable to find patron " + PatronMockOkapi.extPatronId_notFound, msg.errorMessage);
-    assertEquals(expectedStatusCode, (long)msg.httpStatusCode);
+    assertEquals("Unable to find patron " + PatronMockOkapi.extPatronId_notFound, msg.message);
+    assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
   }
 
   @Test
@@ -592,8 +592,8 @@ public class MainVerticleTest {
       .response();
 
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
-    assertEquals("", msg.errorMessage);
-    assertEquals(expectedStatusCode, (long)msg.httpStatusCode);
+    assertEquals("", msg.message);
+    assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
   }
 
   @Test
@@ -616,8 +616,8 @@ public class MainVerticleTest {
 
       ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
 
-      assertEquals(MSG_ACCESS_DENIED, msg.errorMessage);
-      assertEquals(statusCode, (long)msg.httpStatusCode);
+      assertEquals(MSG_ACCESS_DENIED, msg.message);
+      assertEquals(statusCode, (int)msg.httpStatusCode);
   }
 
   @Test
@@ -643,8 +643,8 @@ public class MainVerticleTest {
 
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
 
-    assertEquals(MSG_ACCESS_DENIED, msg.errorMessage);
-    assertEquals(expectedStatusCode, (long)msg.httpStatusCode);
+    assertEquals(MSG_ACCESS_DENIED, msg.message);
+    assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
   }
 
   @Test
@@ -669,8 +669,8 @@ public class MainVerticleTest {
       .response();
 
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
-    assertEquals(MSG_REQUEST_TIMEOUT, msg.errorMessage);
-    assertEquals(expectedStatusCode, (long) msg.httpStatusCode);
+    assertEquals(MSG_REQUEST_TIMEOUT, msg.message);
+    assertEquals(expectedStatusCode, (int) msg.httpStatusCode);
   }
 
   @Test
@@ -688,8 +688,8 @@ public class MainVerticleTest {
       .response();
 
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
-    assertEquals("", msg.errorMessage);
-    assertEquals(expectedStatusCode, (long) msg.httpStatusCode);
+    assertEquals("", msg.message);
+    assertEquals(expectedStatusCode, (int) msg.httpStatusCode);
   }
 
   @Test
@@ -711,8 +711,8 @@ public class MainVerticleTest {
       .response();
 
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
-    assertEquals("Unable to find patron " + PatronMockOkapi.extPatronId_notFound, msg.errorMessage);
-    assertEquals(expectedStatusCode, (long)msg.httpStatusCode);
+    assertEquals("Unable to find patron " + PatronMockOkapi.extPatronId_notFound, msg.message);
+    assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
   }
 
   @Test
@@ -733,8 +733,8 @@ public class MainVerticleTest {
       .response();
 
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
-    assertEquals("", msg.errorMessage);
-    assertEquals(expectedStatusCode, (long) msg.httpStatusCode);
+    assertEquals("", msg.message);
+    assertEquals(expectedStatusCode, (int) msg.httpStatusCode);
   }
 
   @Test
@@ -754,8 +754,8 @@ public class MainVerticleTest {
       .response();
 
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
-    assertEquals("", msg.errorMessage);
-    assertEquals(expectedStatusCode, (long)msg.httpStatusCode);
+    assertEquals("", msg.message);
+    assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
   }
 
   @Test
@@ -776,8 +776,8 @@ public class MainVerticleTest {
 
       ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
 
-    assertEquals(MSG_ACCESS_DENIED, msg.errorMessage );
-    assertEquals(expectedStatusCode, (long)msg.httpStatusCode);
+    assertEquals(MSG_ACCESS_DENIED, msg.message );
+    assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
   }
 
   @Test
@@ -797,8 +797,8 @@ public class MainVerticleTest {
     String actual = resp.body().asString();
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
 
-    assertEquals(MSG_ACCESS_DENIED, msg.errorMessage);
-    assertEquals(expectedStatusCode, (long)msg.httpStatusCode);
+    assertEquals(MSG_ACCESS_DENIED, msg.message);
+    assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
   }
 
   @Test
@@ -819,8 +819,8 @@ public class MainVerticleTest {
       .response();
 
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
-    assertEquals(MSG_REQUEST_TIMEOUT, msg.errorMessage);
-    assertEquals(expectedStatusCode, (long)msg.httpStatusCode);
+    assertEquals(MSG_REQUEST_TIMEOUT, msg.message);
+    assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
   }
 
   @Test
@@ -841,8 +841,8 @@ public class MainVerticleTest {
 
       ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
 
-    assertEquals("", msg.errorMessage );
-    assertEquals(expectedStatusCode, (long)msg.httpStatusCode);
+    assertEquals("", msg.message );
+    assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
   }
 
   @Test
@@ -863,8 +863,8 @@ public class MainVerticleTest {
       .response();
 
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
-    assertEquals("", msg.errorMessage);
-    assertEquals(expectedStatusCode, (long)msg.httpStatusCode);
+    assertEquals("", msg.message);
+    assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
   }
 
   @Test
@@ -885,8 +885,8 @@ public class MainVerticleTest {
       .response();
 
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
-    assertEquals("", msg.errorMessage);
-    assertEquals(expectedStatusCode, (long) msg.httpStatusCode);
+    assertEquals("", msg.message);
+    assertEquals(expectedStatusCode, (int) msg.httpStatusCode);
   }
 
   @Test
@@ -907,8 +907,8 @@ public class MainVerticleTest {
 
       ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
 
-    assertEquals("", msg.errorMessage);
-    assertEquals(expectedStatusCode, (long)msg.httpStatusCode);
+    assertEquals("", msg.message);
+    assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
   }
 
   @Test
@@ -928,8 +928,8 @@ public class MainVerticleTest {
       .response();
 
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
-    assertEquals(MSG_ACCESS_DENIED, msg.errorMessage);
-    assertEquals(expectedStatusCode, (long)msg.httpStatusCode);
+    assertEquals(MSG_ACCESS_DENIED, msg.message);
+    assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
   }
 
   @Test
@@ -949,8 +949,8 @@ public class MainVerticleTest {
 
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
 
-    assertEquals(MSG_ACCESS_DENIED, msg.errorMessage);
-    assertEquals(expectedStatusCode, (long)msg.httpStatusCode);
+    assertEquals(MSG_ACCESS_DENIED, msg.message);
+    assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
   }
 
   @Test
@@ -971,8 +971,8 @@ public class MainVerticleTest {
       .response();
 
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
-    assertEquals(MSG_REQUEST_TIMEOUT, msg.errorMessage);
-    assertEquals(expectedStatusCode, (long)msg.httpStatusCode);
+    assertEquals(MSG_REQUEST_TIMEOUT, msg.message);
+    assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
   }
 
   @Test
@@ -1020,8 +1020,8 @@ public class MainVerticleTest {
       .response();
 
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
-    assertEquals("Unable to find patron " + PatronMockOkapi.extPatronId_notFound, msg.errorMessage);
-    assertEquals(expectedStatusCode, (long)msg.httpStatusCode);
+    assertEquals("Unable to find patron " + PatronMockOkapi.extPatronId_notFound, msg.message);
+    assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
   }
 
   @Test
@@ -1044,8 +1044,8 @@ public class MainVerticleTest {
       .response();
 
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
-    assertEquals(PatronMockOkapi.itemId_notFound + " not found", msg.errorMessage);
-    assertEquals(expectedStatusCode, (long)msg.httpStatusCode);
+    assertEquals(PatronMockOkapi.itemId_notFound + " not found", msg.message);
+    assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
   }
 
   @Test
@@ -1069,8 +1069,8 @@ public class MainVerticleTest {
 
       ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
 
-    assertEquals(MSG_ACCESS_DENIED, msg.errorMessage);
-    assertEquals(expectedStatusCode, (long)msg.httpStatusCode);
+    assertEquals(MSG_ACCESS_DENIED, msg.message);
+    assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
   }
 
   @Test
@@ -1094,8 +1094,8 @@ public class MainVerticleTest {
 
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
 
-    assertEquals(MSG_ACCESS_DENIED, msg.errorMessage);
-    assertEquals(expectedStatusCode, (long)msg.httpStatusCode);
+    assertEquals(MSG_ACCESS_DENIED, msg.message);
+    assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
   }
 
   @Test
@@ -1120,8 +1120,8 @@ public class MainVerticleTest {
       .response();
 
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
-    assertEquals(MSG_REQUEST_TIMEOUT, msg.errorMessage);
-    assertEquals(expectedStatusCode, (long)msg.httpStatusCode);
+    assertEquals(MSG_REQUEST_TIMEOUT, msg.message);
+    assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
   }
 
   @Test
@@ -1161,8 +1161,8 @@ public class MainVerticleTest {
 
       ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
 
-      assertEquals(statusCode, (long)msg.httpStatusCode);
-      assertEquals("Unable to find patron " + PatronMockOkapi.extPatronId_notFound, msg.errorMessage);
+      assertEquals(statusCode, (int)msg.httpStatusCode);
+      assertEquals("Unable to find patron " + PatronMockOkapi.extPatronId_notFound, msg.message);
   }
 
   @Test
@@ -1183,8 +1183,8 @@ public class MainVerticleTest {
       .response();
 
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
-    assertEquals(PatronMockOkapi.itemId_notFound + " not found", msg.errorMessage);
-    assertEquals(expectedStatusCode, (long) msg.httpStatusCode);
+    assertEquals(PatronMockOkapi.itemId_notFound + " not found", msg.message);
+    assertEquals(expectedStatusCode, (int) msg.httpStatusCode);
   }
 
   @Test
@@ -1205,8 +1205,8 @@ public class MainVerticleTest {
       .response();
 
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
-    assertEquals(PatronMockOkapi.holdReqId_notFound  + " not found", msg.errorMessage);
-    assertEquals(expectedStatusCode, (long) msg.httpStatusCode);
+    assertEquals(PatronMockOkapi.holdReqId_notFound  + " not found", msg.message);
+    assertEquals(expectedStatusCode, (int) msg.httpStatusCode);
   }
 
   @Test
@@ -1227,8 +1227,8 @@ public class MainVerticleTest {
 
       ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
 
-    assertEquals(MSG_ACCESS_DENIED, msg.errorMessage);
-    assertEquals(expectedStatusCode, (long)msg.httpStatusCode);
+    assertEquals(MSG_ACCESS_DENIED, msg.message);
+    assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
   }
 
   @Test
@@ -1249,8 +1249,8 @@ public class MainVerticleTest {
     try {
         ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
 
-        assertEquals(MSG_ACCESS_DENIED, msg.errorMessage);
-        assertEquals(expectedStatusCode, (long) msg.httpStatusCode);
+        assertEquals(MSG_ACCESS_DENIED, msg.message);
+        assertEquals(expectedStatusCode, (int) msg.httpStatusCode);
     }
     catch(IOException ex){
         Assert.fail("Exception threw: " + ex.getMessage());
@@ -1275,8 +1275,8 @@ public class MainVerticleTest {
 
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
 
-    assertEquals(MSG_REQUEST_TIMEOUT, msg.errorMessage);
-    assertEquals(expectedStatusCode, (long)msg.httpStatusCode);
+    assertEquals(MSG_REQUEST_TIMEOUT, msg.message);
+    assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
   }
 
   @Test
@@ -1296,8 +1296,8 @@ public class MainVerticleTest {
       .response();
 
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
-    assertEquals("", msg.errorMessage);
-    assertEquals(expectedStatusCode, (long)msg.httpStatusCode);
+    assertEquals("", msg.message);
+    assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
   }
 
   @Test
@@ -1318,8 +1318,8 @@ public class MainVerticleTest {
       .response();
 
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
-    assertEquals("Unable to find patron " + PatronMockOkapi.extPatronId_notFound, msg.errorMessage);
-    assertEquals(expectedStatusCode, (long)msg.httpStatusCode);
+    assertEquals("Unable to find patron " + PatronMockOkapi.extPatronId_notFound, msg.message);
+    assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
   }
 
   @Test
@@ -1339,8 +1339,8 @@ public class MainVerticleTest {
       .response();
 
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
-    assertEquals(PatronMockOkapi.itemId_notFound + " not found", msg.errorMessage);
-    assertEquals(expectedStatusCode, (long)msg.httpStatusCode);
+    assertEquals(PatronMockOkapi.itemId_notFound + " not found", msg.message);
+    assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
   }
 
   @Test
@@ -1361,8 +1361,8 @@ public class MainVerticleTest {
       .response();
 
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
-    assertEquals(PatronMockOkapi.holdReqId_notFound + " not found", msg.errorMessage);
-    assertEquals(expectedStatusCode, (long)msg.httpStatusCode);
+    assertEquals(PatronMockOkapi.holdReqId_notFound + " not found", msg.message);
+    assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
   }
 
   @Test
@@ -1382,8 +1382,8 @@ public class MainVerticleTest {
       .response();
 
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
-    assertEquals(MSG_ACCESS_DENIED, msg.errorMessage);
-    assertEquals(expectedStatusCode, (long)msg.httpStatusCode);
+    assertEquals(MSG_ACCESS_DENIED, msg.message);
+    assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
   }
 
   @Test
@@ -1402,8 +1402,8 @@ public class MainVerticleTest {
 
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
 
-    assertEquals(MSG_ACCESS_DENIED, msg.errorMessage);
-    assertEquals(expectedStatusCode, (long)msg.httpStatusCode);
+    assertEquals(MSG_ACCESS_DENIED, msg.message);
+    assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
   }
 
   @Test
@@ -1424,8 +1424,8 @@ public class MainVerticleTest {
       .response();
 
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
-    assertEquals(MSG_REQUEST_TIMEOUT, msg.errorMessage);
-    assertEquals(expectedStatusCode, (long)msg.httpStatusCode);
+    assertEquals(MSG_REQUEST_TIMEOUT, msg.message);
+    assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
   }
 
   @Test

--- a/src/test/java/org/folio/edge/patron/MainVerticleTest.java
+++ b/src/test/java/org/folio/edge/patron/MainVerticleTest.java
@@ -27,7 +27,7 @@ import org.apache.log4j.Logger;
 import org.folio.edge.core.InstitutionalUserHelper;
 import org.folio.edge.core.utils.test.TestUtils;
 import org.folio.edge.patron.model.Account;
-import org.folio.edge.patron.model.ErrorMessage;
+import org.folio.edge.patron.model.error.ErrorMessage;
 import org.folio.edge.patron.model.Hold;
 import org.folio.edge.patron.model.Loan;
 import org.folio.edge.patron.utils.PatronMockOkapi;
@@ -455,6 +455,72 @@ public class MainVerticleTest {
     assertEquals(MSG_REQUEST_TIMEOUT, msg.errorMessage);
     assertEquals(expectedStatusCode, (long)msg.httpStatusCode);
   }
+
+    @Test
+    public void testRenewRequesMaxRenewal(TestContext context) throws Exception {
+        logger.info("=== Test MAX Renewal ===");
+
+        int expectedStatusCode = 422;
+
+        final Response resp = RestAssured
+                .with()
+                .post(String.format("/patron/account/%s/item/%s/renew?apikey=%s", patronId, PatronMockOkapi.itemId_reached_max_renewals,
+                        apiKey))
+                .then()
+                .contentType(APPLICATION_JSON)
+                .statusCode(expectedStatusCode)
+                .extract()
+                .response();
+
+        ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
+
+        assertEquals("loan has reached its maximum number of renewals", msg.errorMessage);
+        assertEquals(expectedStatusCode, (long)msg.httpStatusCode);
+    }
+
+    @Test
+    public void testRenewRequesMaxRenewalWithEmptyErrors(TestContext context) throws Exception {
+        logger.info("=== Test MAX Renewal With Empty Errors ===");
+
+        int expectedStatusCode = 422;
+
+        final Response resp = RestAssured
+                .with()
+                .post(String.format("/patron/account/%s/item/%s/renew?apikey=%s", patronId, PatronMockOkapi.itemId_reached_max_renewals_empty_error_msg,
+                        apiKey))
+                .then()
+                .contentType(APPLICATION_JSON)
+                .statusCode(expectedStatusCode)
+                .extract()
+                .response();
+
+        ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
+
+        assertEquals("No error message found", msg.errorMessage);
+        assertEquals(expectedStatusCode, (long)msg.httpStatusCode);
+    }
+
+    @Test
+    public void testRenewRequesMaxRenewalWithBadJson(TestContext context) throws Exception {
+        logger.info("=== Test MAX Renewal With Bad Json ===");
+
+        int expectedStatusCode = 422;
+
+        final Response resp = RestAssured
+                .with()
+                .post(String.format("/patron/account/%s/item/%s/renew?apikey=%s", patronId, PatronMockOkapi.itemId_reached_max_renewals_bad_json_msg,
+                        apiKey))
+                .then()
+                .contentType(APPLICATION_JSON)
+                .statusCode(expectedStatusCode)
+                .extract()
+                .response();
+
+        ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
+
+        assertEquals("A problem encountered when extracting error message", msg.errorMessage);
+        assertEquals(expectedStatusCode, (long)msg.httpStatusCode);
+    }
 
   @Test
   public void testPlaceInstanceHoldSuccess(TestContext context) throws Exception {

--- a/src/test/java/org/folio/edge/patron/MainVerticleTest.java
+++ b/src/test/java/org/folio/edge/patron/MainVerticleTest.java
@@ -139,7 +139,7 @@ public class MainVerticleTest {
 
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
     assertEquals(MSG_ACCESS_DENIED, msg.message);
-    assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
+    assertEquals(expectedStatusCode, msg.httpStatusCode);
   }
 
   @Test
@@ -159,7 +159,7 @@ public class MainVerticleTest {
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
 
     assertEquals(MSG_ACCESS_DENIED, msg.message);
-    assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
+    assertEquals(expectedStatusCode, msg.httpStatusCode);
   }
 
   @Test
@@ -197,7 +197,7 @@ public class MainVerticleTest {
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
 
     assertEquals("Unable to find patron " + PatronMockOkapi.extPatronId_notFound, msg.message);
-    assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
+    assertEquals(expectedStatusCode, msg.httpStatusCode);
   }
 
   @Test
@@ -217,7 +217,7 @@ public class MainVerticleTest {
       ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
 
     assertEquals(MSG_ACCESS_DENIED, msg.message);
-    assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
+    assertEquals(expectedStatusCode, msg.httpStatusCode);
   }
 
   @Test
@@ -331,7 +331,7 @@ public class MainVerticleTest {
       ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
 
       assertEquals(MSG_REQUEST_TIMEOUT, msg.message);
-      assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
+      assertEquals(expectedStatusCode, msg.httpStatusCode);
   }
 
   @Test
@@ -371,7 +371,7 @@ public class MainVerticleTest {
 
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
     assertEquals("Unable to find patron " + PatronMockOkapi.extPatronId_notFound, msg.message);
-    assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
+    assertEquals(expectedStatusCode, msg.httpStatusCode);
   }
 
   @Test
@@ -392,7 +392,7 @@ public class MainVerticleTest {
 
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
     assertEquals(PatronMockOkapi.itemId_notFound + " not found", msg.message);
-    assertEquals(expectedStatusCode, (int) msg.httpStatusCode);
+    assertEquals(expectedStatusCode,  msg.httpStatusCode);
   }
 
   @Test
@@ -412,7 +412,7 @@ public class MainVerticleTest {
       ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
 
     assertEquals(MSG_ACCESS_DENIED, msg.message);
-    assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
+    assertEquals(expectedStatusCode, msg.httpStatusCode);
   }
 
   @Test
@@ -430,7 +430,7 @@ public class MainVerticleTest {
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
 
     assertEquals(MSG_ACCESS_DENIED, msg.message);
-    assertEquals(401, (int)msg.httpStatusCode);
+    assertEquals(401, msg.httpStatusCode);
   }
 
   @Test
@@ -453,7 +453,7 @@ public class MainVerticleTest {
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
 
     assertEquals(MSG_REQUEST_TIMEOUT, msg.message);
-    assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
+    assertEquals(expectedStatusCode, msg.httpStatusCode);
   }
 
     @Test
@@ -475,7 +475,7 @@ public class MainVerticleTest {
         ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
 
         assertEquals("loan has reached its maximum number of renewals", msg.message);
-        assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
+        assertEquals(expectedStatusCode, msg.httpStatusCode);
     }
 
     @Test
@@ -497,7 +497,7 @@ public class MainVerticleTest {
         ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
 
         assertEquals("No error message found", msg.message);
-        assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
+        assertEquals(expectedStatusCode, msg.httpStatusCode);
     }
 
     @Test
@@ -519,7 +519,7 @@ public class MainVerticleTest {
         ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
 
         assertEquals("A problem encountered when extracting error message", msg.message);
-        assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
+        assertEquals(expectedStatusCode, msg.httpStatusCode);
     }
 
   @Test
@@ -543,7 +543,7 @@ public class MainVerticleTest {
 
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
     assertEquals("", msg.message);
-    assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
+    assertEquals(expectedStatusCode, msg.httpStatusCode);
   }
 
   @Test
@@ -569,7 +569,7 @@ public class MainVerticleTest {
 
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
     assertEquals("Unable to find patron " + PatronMockOkapi.extPatronId_notFound, msg.message);
-    assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
+    assertEquals(expectedStatusCode, msg.httpStatusCode);
   }
 
   @Test
@@ -593,7 +593,7 @@ public class MainVerticleTest {
 
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
     assertEquals("", msg.message);
-    assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
+    assertEquals(expectedStatusCode, msg.httpStatusCode);
   }
 
   @Test
@@ -617,7 +617,7 @@ public class MainVerticleTest {
       ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
 
       assertEquals(MSG_ACCESS_DENIED, msg.message);
-      assertEquals(statusCode, (int)msg.httpStatusCode);
+      assertEquals(statusCode, msg.httpStatusCode);
   }
 
   @Test
@@ -644,7 +644,7 @@ public class MainVerticleTest {
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
 
     assertEquals(MSG_ACCESS_DENIED, msg.message);
-    assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
+    assertEquals(expectedStatusCode, msg.httpStatusCode);
   }
 
   @Test
@@ -670,7 +670,7 @@ public class MainVerticleTest {
 
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
     assertEquals(MSG_REQUEST_TIMEOUT, msg.message);
-    assertEquals(expectedStatusCode, (int) msg.httpStatusCode);
+    assertEquals(expectedStatusCode,  msg.httpStatusCode);
   }
 
   @Test
@@ -689,7 +689,7 @@ public class MainVerticleTest {
 
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
     assertEquals("", msg.message);
-    assertEquals(expectedStatusCode, (int) msg.httpStatusCode);
+    assertEquals(expectedStatusCode,  msg.httpStatusCode);
   }
 
   @Test
@@ -712,7 +712,7 @@ public class MainVerticleTest {
 
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
     assertEquals("Unable to find patron " + PatronMockOkapi.extPatronId_notFound, msg.message);
-    assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
+    assertEquals(expectedStatusCode, msg.httpStatusCode);
   }
 
   @Test
@@ -734,7 +734,7 @@ public class MainVerticleTest {
 
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
     assertEquals("", msg.message);
-    assertEquals(expectedStatusCode, (int) msg.httpStatusCode);
+    assertEquals(expectedStatusCode,  msg.httpStatusCode);
   }
 
   @Test
@@ -755,7 +755,7 @@ public class MainVerticleTest {
 
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
     assertEquals("", msg.message);
-    assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
+    assertEquals(expectedStatusCode, msg.httpStatusCode);
   }
 
   @Test
@@ -777,7 +777,7 @@ public class MainVerticleTest {
       ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
 
     assertEquals(MSG_ACCESS_DENIED, msg.message );
-    assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
+    assertEquals(expectedStatusCode, msg.httpStatusCode);
   }
 
   @Test
@@ -798,7 +798,7 @@ public class MainVerticleTest {
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
 
     assertEquals(MSG_ACCESS_DENIED, msg.message);
-    assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
+    assertEquals(expectedStatusCode, msg.httpStatusCode);
   }
 
   @Test
@@ -820,7 +820,7 @@ public class MainVerticleTest {
 
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
     assertEquals(MSG_REQUEST_TIMEOUT, msg.message);
-    assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
+    assertEquals(expectedStatusCode, msg.httpStatusCode);
   }
 
   @Test
@@ -842,7 +842,7 @@ public class MainVerticleTest {
       ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
 
     assertEquals("", msg.message );
-    assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
+    assertEquals(expectedStatusCode, msg.httpStatusCode);
   }
 
   @Test
@@ -864,7 +864,7 @@ public class MainVerticleTest {
 
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
     assertEquals("", msg.message);
-    assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
+    assertEquals(expectedStatusCode, msg.httpStatusCode);
   }
 
   @Test
@@ -886,7 +886,7 @@ public class MainVerticleTest {
 
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
     assertEquals("", msg.message);
-    assertEquals(expectedStatusCode, (int) msg.httpStatusCode);
+    assertEquals(expectedStatusCode,  msg.httpStatusCode);
   }
 
   @Test
@@ -908,7 +908,7 @@ public class MainVerticleTest {
       ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
 
     assertEquals("", msg.message);
-    assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
+    assertEquals(expectedStatusCode, msg.httpStatusCode);
   }
 
   @Test
@@ -929,7 +929,7 @@ public class MainVerticleTest {
 
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
     assertEquals(MSG_ACCESS_DENIED, msg.message);
-    assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
+    assertEquals(expectedStatusCode, msg.httpStatusCode);
   }
 
   @Test
@@ -950,7 +950,7 @@ public class MainVerticleTest {
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
 
     assertEquals(MSG_ACCESS_DENIED, msg.message);
-    assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
+    assertEquals(expectedStatusCode, msg.httpStatusCode);
   }
 
   @Test
@@ -972,7 +972,7 @@ public class MainVerticleTest {
 
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
     assertEquals(MSG_REQUEST_TIMEOUT, msg.message);
-    assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
+    assertEquals(expectedStatusCode, msg.httpStatusCode);
   }
 
   @Test
@@ -1021,7 +1021,7 @@ public class MainVerticleTest {
 
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
     assertEquals("Unable to find patron " + PatronMockOkapi.extPatronId_notFound, msg.message);
-    assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
+    assertEquals(expectedStatusCode, msg.httpStatusCode);
   }
 
   @Test
@@ -1045,7 +1045,7 @@ public class MainVerticleTest {
 
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
     assertEquals(PatronMockOkapi.itemId_notFound + " not found", msg.message);
-    assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
+    assertEquals(expectedStatusCode, msg.httpStatusCode);
   }
 
   @Test
@@ -1070,7 +1070,7 @@ public class MainVerticleTest {
       ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
 
     assertEquals(MSG_ACCESS_DENIED, msg.message);
-    assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
+    assertEquals(expectedStatusCode, msg.httpStatusCode);
   }
 
   @Test
@@ -1095,7 +1095,7 @@ public class MainVerticleTest {
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
 
     assertEquals(MSG_ACCESS_DENIED, msg.message);
-    assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
+    assertEquals(expectedStatusCode, msg.httpStatusCode);
   }
 
   @Test
@@ -1121,7 +1121,7 @@ public class MainVerticleTest {
 
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
     assertEquals(MSG_REQUEST_TIMEOUT, msg.message);
-    assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
+    assertEquals(expectedStatusCode, msg.httpStatusCode);
   }
 
   @Test
@@ -1161,7 +1161,7 @@ public class MainVerticleTest {
 
       ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
 
-      assertEquals(statusCode, (int)msg.httpStatusCode);
+      assertEquals(statusCode, msg.httpStatusCode);
       assertEquals("Unable to find patron " + PatronMockOkapi.extPatronId_notFound, msg.message);
   }
 
@@ -1184,7 +1184,7 @@ public class MainVerticleTest {
 
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
     assertEquals(PatronMockOkapi.itemId_notFound + " not found", msg.message);
-    assertEquals(expectedStatusCode, (int) msg.httpStatusCode);
+    assertEquals(expectedStatusCode,  msg.httpStatusCode);
   }
 
   @Test
@@ -1206,7 +1206,7 @@ public class MainVerticleTest {
 
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
     assertEquals(PatronMockOkapi.holdReqId_notFound  + " not found", msg.message);
-    assertEquals(expectedStatusCode, (int) msg.httpStatusCode);
+    assertEquals(expectedStatusCode,  msg.httpStatusCode);
   }
 
   @Test
@@ -1228,7 +1228,7 @@ public class MainVerticleTest {
       ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
 
     assertEquals(MSG_ACCESS_DENIED, msg.message);
-    assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
+    assertEquals(expectedStatusCode, msg.httpStatusCode);
   }
 
   @Test
@@ -1250,7 +1250,7 @@ public class MainVerticleTest {
         ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
 
         assertEquals(MSG_ACCESS_DENIED, msg.message);
-        assertEquals(expectedStatusCode, (int) msg.httpStatusCode);
+        assertEquals(expectedStatusCode,  msg.httpStatusCode);
     }
     catch(IOException ex){
         Assert.fail("Exception threw: " + ex.getMessage());
@@ -1276,7 +1276,7 @@ public class MainVerticleTest {
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
 
     assertEquals(MSG_REQUEST_TIMEOUT, msg.message);
-    assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
+    assertEquals(expectedStatusCode, msg.httpStatusCode);
   }
 
   @Test
@@ -1297,7 +1297,7 @@ public class MainVerticleTest {
 
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
     assertEquals("", msg.message);
-    assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
+    assertEquals(expectedStatusCode, msg.httpStatusCode);
   }
 
   @Test
@@ -1319,7 +1319,7 @@ public class MainVerticleTest {
 
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
     assertEquals("Unable to find patron " + PatronMockOkapi.extPatronId_notFound, msg.message);
-    assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
+    assertEquals(expectedStatusCode, msg.httpStatusCode);
   }
 
   @Test
@@ -1340,7 +1340,7 @@ public class MainVerticleTest {
 
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
     assertEquals(PatronMockOkapi.itemId_notFound + " not found", msg.message);
-    assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
+    assertEquals(expectedStatusCode, msg.httpStatusCode);
   }
 
   @Test
@@ -1362,7 +1362,7 @@ public class MainVerticleTest {
 
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
     assertEquals(PatronMockOkapi.holdReqId_notFound + " not found", msg.message);
-    assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
+    assertEquals(expectedStatusCode, msg.httpStatusCode);
   }
 
   @Test
@@ -1383,7 +1383,7 @@ public class MainVerticleTest {
 
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
     assertEquals(MSG_ACCESS_DENIED, msg.message);
-    assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
+    assertEquals(expectedStatusCode, msg.httpStatusCode);
   }
 
   @Test
@@ -1403,7 +1403,7 @@ public class MainVerticleTest {
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
 
     assertEquals(MSG_ACCESS_DENIED, msg.message);
-    assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
+    assertEquals(expectedStatusCode, msg.httpStatusCode);
   }
 
   @Test
@@ -1425,7 +1425,7 @@ public class MainVerticleTest {
 
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
     assertEquals(MSG_REQUEST_TIMEOUT, msg.message);
-    assertEquals(expectedStatusCode, (int)msg.httpStatusCode);
+    assertEquals(expectedStatusCode, msg.httpStatusCode);
   }
 
   @Test

--- a/src/test/java/org/folio/edge/patron/model/error/ErrorMessageTest.java
+++ b/src/test/java/org/folio/edge/patron/model/error/ErrorMessageTest.java
@@ -1,0 +1,71 @@
+package org.folio.edge.patron.model.error;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class ErrorMessageTest {
+
+    @Test
+    public void TestErrorMessageEquals(){
+        ErrorMessage messageOne = new ErrorMessage(400, "text");
+        ErrorMessage messageTwo = new ErrorMessage(400, "text");
+
+        assertEquals(messageOne, messageTwo);
+        assertEquals(messageOne, messageOne);
+    }
+
+    @Test
+    public void TestErrorMessageNotEquals(){
+
+        ErrorMessage messageOne = new ErrorMessage(400, "text");
+        assertNotEquals(messageOne, null);
+        assertNotEquals(messageOne, new Integer(5));
+
+
+        ErrorMessage messageTwo = new ErrorMessage(401, "text");
+        assertNotEquals(messageOne, messageTwo);
+
+        ErrorMessage messageThree  = new ErrorMessage(400, "text2");
+        assertNotEquals(messageOne, messageThree);
+
+        ErrorMessage messageFour = new ErrorMessage(400, null);
+        assertNotEquals(messageOne, messageFour);
+    }
+
+    @Test
+    public void TestErrorMessageToXml(){
+
+        ErrorMessage msg  = new ErrorMessage(400, "hi");
+        String expectedXml = "<?xml version='1.0' encoding='UTF-8'?>\n" +
+                "<error>\n" +
+                "  <code>400</code>\n" +
+                "  <message>hi</message>\n" +
+                "</error>\n";
+
+        try {
+            String xmlMsg = msg.toXml();
+            assertEquals(expectedXml, xmlMsg);
+        }
+        catch(Exception ex){
+            fail("can't convert to ErrorMessage to xml");
+        }
+    }
+
+    @Test
+    public void TestErrorMessagefromXml(){
+
+        ErrorMessage expectedMsg  = new ErrorMessage(400, "hi");
+        String inputXml = "<?xml version='1.0' encoding='UTF-8'?>\n" +
+                "<error>\n" +
+                "  <code>400</code>\n" +
+                "  <message>hi</message>\n" +
+                "</error>\n";
+
+        try {
+            ErrorMessage errorMessageFromXml = ErrorMessage.fromXml(inputXml);
+            assertEquals(expectedMsg, errorMessageFromXml);
+        }
+        catch(Exception ex){
+            fail("can't convert xml to ErrorMessage");
+        }
+    }
+}

--- a/src/test/java/org/folio/edge/patron/model/error/ErrorTest.java
+++ b/src/test/java/org/folio/edge/patron/model/error/ErrorTest.java
@@ -1,0 +1,109 @@
+package org.folio.edge.patron.model.error;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class ErrorTest {
+
+    @Test
+    public void typeTests(){
+        Error error = new Error();
+
+
+        error.withType("typeA");
+        String aCode = error.getType();
+        assertEquals("typeA", aCode);
+
+        assertEquals("typeA", error.getType());
+
+        error.setType("typeB");
+        assertEquals("typeB", error.getType());
+    }
+
+    @Test
+    public void codeTests(){
+        Error error = new Error();
+
+
+        error.withCode("CodeRed");
+        String aCode = error.getCode();
+        assertEquals("CodeRed", aCode);
+
+        assertEquals("CodeRed", error.getCode());
+
+        error.setCode("CodeBlue");
+        assertEquals("CodeBlue", error.getCode());
+    }
+
+    @Test
+    public void additionalPropertiesTests(){
+
+        Error error = new Error();
+
+        error.setAdditionalProperty("prop1", "property1");
+        error.setAdditionalProperty("prop2", "property2");
+        error.setAdditionalProperty("prop3", "property3");
+
+        Map<String, Object> addlProps = error.getAdditionalProperties();
+
+        assertEquals(3, addlProps.size());
+        assertEquals( "property1", addlProps.get("prop1"));
+        assertEquals( "property2", addlProps.get("prop2"));
+        assertEquals( "property3", addlProps.get("prop3"));
+
+
+        error.withAdditionalProperty("prop4", "property4");
+        assertEquals("property4", error.getAdditionalProperties().get("prop4"));
+    }
+
+    @Test
+    public void messageTests(){
+        Error error = new Error();
+
+        error.withMessage("small message");
+        String theMessage = error.getMessage();
+
+        assertEquals("small message", theMessage);
+
+        error.setMessage("big message");
+        assertEquals("big message", error.getMessage());
+    }
+
+    @Test
+    public void parameterTests(){
+        Error error = new Error();
+
+        Parameter param1 = new Parameter();
+        param1.setKey("key1");
+        param1.setValue("val1");
+
+        Parameter param2 = new Parameter();
+        param2.setKey("key2");
+        param2.setValue("val2");
+
+        List<Parameter> parameterList = new ArrayList<>();
+        parameterList.add(param1);
+        parameterList.add(param2);
+
+        error.withParameters(parameterList);
+        List<Parameter> returnedParams = error.getParameters();
+
+        assertNotNull(returnedParams);
+        assertEquals(parameterList, returnedParams);
+        assertEquals(parameterList.size(), returnedParams.size());
+
+        List<Parameter> list3 = new ArrayList<>();
+        list3.add(param1);
+        error.setParameters(list3);
+
+        List<Parameter> returnedList3 = error.getParameters();
+
+        assertNotNull(returnedList3);
+        assertEquals(list3, returnedList3);
+        assertEquals(list3.size(), returnedList3.size());
+    }
+}

--- a/src/test/java/org/folio/edge/patron/model/error/ErrorsTest.java
+++ b/src/test/java/org/folio/edge/patron/model/error/ErrorsTest.java
@@ -1,0 +1,70 @@
+package org.folio.edge.patron.model.error;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class ErrorsTest {
+
+    @Test
+    public void withErrorsTest(){
+
+        Error error1 = new Error();
+        Error error2 = new Error();
+        Error error3 = new Error();
+
+        List<Error> errorList = new ArrayList<>();
+        errorList.add(error1);
+        errorList.add(error2);
+        errorList.add(error3);
+
+        Errors errors = new Errors();
+        Errors errors2 = errors.withErrors(errorList);
+
+        assertEquals(errors, errors2);
+        assertEquals(3, errors.getErrors().size());
+        assertEquals(error1, errors.getErrors().get(0));
+        assertEquals(error2, errors.getErrors().get(1));
+        assertEquals(error3, errors.getErrors().get(2));
+    }
+
+    @Test
+    public void totalRecordsTests(){
+        Errors errors = new Errors();
+        Errors returnedErrors = errors.withTotalRecords(5);
+
+
+        assertEquals(errors, returnedErrors);
+        assertEquals(5, returnedErrors.getTotalRecords().intValue());
+
+
+        errors.setTotalRecords(7);
+        int totalRecords = errors.getTotalRecords();
+        assertEquals(7, totalRecords);
+    }
+
+    @Test
+    public void additionalPropertiesTests(){
+
+        Errors errors = new Errors();
+
+        errors.setAdditionalProperty("prop1", "property1");
+        errors.setAdditionalProperty("prop2", "property2");
+        errors.setAdditionalProperty("prop3", "property3");
+
+        Map<String, Object> addlProps = errors.getAdditionalProperties();
+
+        assertEquals(3, addlProps.size());
+        assertEquals( "property1", addlProps.get("prop1"));
+        assertEquals( "property2", addlProps.get("prop2"));
+        assertEquals( "property3", addlProps.get("prop3"));
+
+
+        errors.withAdditionalProperty("prop4", "property4");
+        assertEquals("property4", errors.getAdditionalProperties().get("prop4"));
+    }
+
+}

--- a/src/test/java/org/folio/edge/patron/model/error/ParameterTest.java
+++ b/src/test/java/org/folio/edge/patron/model/error/ParameterTest.java
@@ -1,0 +1,60 @@
+package org.folio.edge.patron.model.error;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static org.junit.Assert.*;
+
+public class ParameterTest {
+
+    @Test
+    public void set_get_AdditionalProperties(){
+
+        Parameter param = new Parameter();
+
+        param.setAdditionalProperty("prop1", "property1");
+        param.setAdditionalProperty("prop2", "property2");
+        param.setAdditionalProperty("prop3", "property3");
+
+        Map<String, Object> addlProps = param.getAdditionalProperties();
+
+        assertEquals(3, addlProps.size());
+        assertEquals( "property1", addlProps.get("prop1"));
+        assertEquals( "property2", addlProps.get("prop2"));
+        assertEquals( "property3", addlProps.get("prop3"));
+
+
+        param.withAdditionalProperty("prop4", "property4");
+        assertEquals("property4", param.getAdditionalProperties().get("prop4"));
+    }
+
+    @Test
+    public void valueTests()
+    {
+        Parameter param = new Parameter();
+        param.setValue("value1");
+
+        String paramValue = param.getValue();
+        assertEquals("value1", paramValue);
+
+        Parameter returnedParam = param.withValue("value2");
+        assertNotNull(returnedParam);
+        assertEquals(param, returnedParam);
+        assertEquals("value2", returnedParam.getValue());
+    }
+
+    @Test
+    public void keyTests()
+    {
+        Parameter param = new Parameter();
+        param.setKey("key1");
+
+        String paramKey = param.getKey();
+        assertEquals("key1", paramKey);
+
+        Parameter returnedParam = param.withKey("key2");
+        assertNotNull(returnedParam);
+        assertEquals(param, returnedParam);
+        assertEquals("key2", returnedParam.getKey());
+    }
+}

--- a/src/test/java/org/folio/edge/patron/utils/PatronMockOkapi.java
+++ b/src/test/java/org/folio/edge/patron/utils/PatronMockOkapi.java
@@ -58,6 +58,10 @@ public class PatronMockOkapi extends MockOkapi {
   public static final String extPatronId = UUID.randomUUID().toString();
   public static final String extPatronId_notFound = UUID.randomUUID().toString();
   public static final String feeFineId = UUID.randomUUID().toString();
+  public static final String itemId_reached_max_renewals = UUID.randomUUID().toString();
+  public static final String itemId_reached_max_renewals_empty_error_msg = UUID.randomUUID().toString();
+  public static final String itemId_reached_max_renewals_bad_json_msg = UUID.randomUUID().toString();
+
 
   public static final long checkedOutTs = System.currentTimeMillis() - (34 * DAY_IN_MILLIS);
   public static final long dueDateTs = checkedOutTs + (20 * DAY_IN_MILLIS);
@@ -65,6 +69,36 @@ public class PatronMockOkapi extends MockOkapi {
 
   public static final long holdExpTs = System.currentTimeMillis() + (59 * DAY_IN_MILLIS);
   public static final long holdReqTs = System.currentTimeMillis() - DAY_IN_MILLIS;
+
+  public static final String Sample422ErrorMsg = "{" +
+          "\"errors\" : [ {" +
+          "\"message\" : \"loan has reached its maximum number of renewals\"," +
+          "\"parameters\" : [ {" +
+          "\"key\" : \"loanPolicyName\"," +
+          "\"value\" : \"Example Loan Policy\"" +
+          "}, {" +
+          "\"key\" : \"loanPolicyId\"," +
+          "\"value\" : \"d9cd0bed-1b49-4b5e-a7bd-064b8d177231\"" +
+          "} ]" +
+          "} ]" +
+          "}";
+
+  public static final String Sample422BadJsonErrorMsg = "{" +
+          "\"errors\" : [ {" +
+          "\"message\" : \"loan has reached its maximum number of renewals\"," +
+          "\"parameters\" : [ " +
+          "\"key\" : \"loanPolicyName\"," +
+          "\"value\" : \"Example Loan Policy\"" +
+          "}, {" +
+          "\"key\" : \"loanPolicyId\"," +
+          "\"value\" : \"d9cd0bed-1b49-4b5e-a7bd-064b8d177231\"" +
+          "} ]" +
+          "} ]" +
+          "}";
+
+  public static final String SampleEmpty422ErrorMsg = "{" +
+          "\"errors\" : []" +
+          "}";
 
   public PatronMockOkapi(int port, List<String> knownTenants) {
     super(port, knownTenants);
@@ -175,7 +209,22 @@ public class PatronMockOkapi extends MockOkapi {
         .setStatusCode(404)
         .putHeader(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN)
         .end(itemId + " not found");
-    } else {
+    } else if (itemId.equals(itemId_reached_max_renewals)) {
+      ctx.response()
+              .setStatusCode(422)
+              .putHeader(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON)
+              .end(Sample422ErrorMsg);
+    }else if (itemId.equals(itemId_reached_max_renewals_empty_error_msg)) {
+      ctx.response()
+              .setStatusCode(422)
+              .putHeader(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON)
+              .end(SampleEmpty422ErrorMsg);
+    }else if (itemId.equals(itemId_reached_max_renewals_bad_json_msg)){
+      ctx.response()
+              .setStatusCode(422)
+              .putHeader(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON)
+              .end(Sample422BadJsonErrorMsg);
+    }else {
       ctx.response()
         .setStatusCode(201)
         .putHeader(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON)


### PR DESCRIPTION
Added a wrapper around the 400-500 error messages.
For errors with status code of 422, extracted the first error's message and created a wrapper around it. 
Added appropriate unit tests.
The Errors structures (Errors.java, Error.java, Parameter.java) are copied and pasted from generated code to reduce complexity.  I could potentially pull in the generated code instead of creating them anew here. 