### PR TITLE
EDGPATRON-18: update the login interface dependency to include 6.0

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -9,7 +9,7 @@
     },
     {
       "id": "login",
-      "version": "5.0"
+      "version": "5.0 6.0"
     }
   ],
   "permissionSets": [],

--- a/pom.xml
+++ b/pom.xml
@@ -195,29 +195,16 @@
 
   <build>
     <pluginManagement>
+      <!--
+           The super pom declares these dependencies and versions. Eclipse warns when versions
+           are specified for plugins that are controlled by pluginManagement. By declaring them
+           here we avoid these warnings and ensure we are getting the expected versions, in case
+           the super pom changes versions for some reason.
+      -->
       <plugins>
-        <!-- We specify the Maven compiler plugin as we need to set it to
-          Java 1.8 -->
         <plugin>
-          <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.1</version>
-          <configuration>
-            <source>${maven.compiler.source}</source>
-            <target>${maven.compiler.target}</target>
-          </configuration>
-        </plugin>
-
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.22.1</version>
-          <configuration>
-            <!-- TODO: update to version 3.0.0 and remove useSystemClassLoader
-                 https://issues.folio.org/browse/FOLIO-1609
-                 https://issues.apache.org/jira/browse/SUREFIRE-1588
-            -->
-            <useSystemClassLoader>false</useSystemClassLoader>
-          </configuration>
+          <artifactId>maven-release-plugin</artifactId>
+          <version>2.5.3</version>
         </plugin>
       </plugins>
     </pluginManagement>
@@ -327,15 +314,39 @@
           </execution>
         </executions>
       </plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-release-plugin</artifactId>
-        <version>2.5.3</version>
         <configuration>
           <preparationGoals>clean verify</preparationGoals>
           <tagNameFormat>v@{project.version}</tagNameFormat>
           <pushChanges>false</pushChanges>
           <localCheckout>true</localCheckout>
+        </configuration>
+      </plugin>
+
+      <!-- We specify the Maven compiler plugin as we need to set it to
+        Java 1.8 -->
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <version>3.1</version>
+        <configuration>
+          <source>${maven.compiler.source}</source>
+          <target>${maven.compiler.target}</target>
+        </configuration>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.22.1</version>
+        <configuration>
+          <!-- TODO: update to version 3.0.0 and remove useSystemClassLoader
+               https://issues.folio.org/browse/FOLIO-1609
+               https://issues.apache.org/jira/browse/SUREFIRE-1588
+          -->
+          <useSystemClassLoader>false</useSystemClassLoader>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
We need to update the version of the `login` interface to include `6.0` in order to be compatible with the current release.

Also fixed some pom file Eclipse warnings.