### PR TITLE
EDGPATRON-19: Set request creation and expiration dates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 .settings
 .vertx
 /bin/
+#IntelliJ
+.idea/
+*.iml

--- a/ramls/hold.json
+++ b/ramls/hold.json
@@ -47,7 +47,6 @@
     }
   },
   "required": [
-    "requestDate",
     "pickupLocationId"
   ]
 }

--- a/ramls/patron.xsd
+++ b/ramls/patron.xsd
@@ -33,7 +33,7 @@
     <xs:sequence>
       <xs:element name="requestId" type="xs:string" minOccurs="0" maxOccurs="1"/>
       <xs:element ref="item" minOccurs="0" maxOccurs="1"/>
-      <xs:element name="requestDate" type="requiredString" minOccurs="1" maxOccurs="1"/>
+      <xs:element name="requestDate" type="xs:string" minOccurs="0" maxOccurs="1"/>
       <xs:element name="expirationDate" type="xs:string" minOccurs="0" maxOccurs="1"/>
       <xs:element name="pickupLocationId" type="requiredString" minOccurs="1" maxOccurs="1"/>
       <xs:element name="status" minOccurs="0" maxOccurs="1">

--- a/src/test/java/org/folio/edge/patron/MainVerticleTest.java
+++ b/src/test/java/org/folio/edge/patron/MainVerticleTest.java
@@ -1,6 +1,5 @@
 package org.folio.edge.patron;
 
-import static junit.framework.TestCase.assertTrue;
 import static org.folio.edge.core.Constants.APPLICATION_JSON;
 import static org.folio.edge.core.Constants.DAY_IN_MILLIS;
 import static org.folio.edge.core.Constants.SYS_LOG_LEVEL;
@@ -14,6 +13,7 @@ import static org.folio.edge.patron.Constants.MSG_ACCESS_DENIED;
 import static org.folio.edge.patron.Constants.MSG_REQUEST_TIMEOUT;
 import static org.folio.edge.patron.utils.PatronMockOkapi.holdReqTs;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.atLeast;

--- a/src/test/java/org/folio/edge/patron/MainVerticleTest.java
+++ b/src/test/java/org/folio/edge/patron/MainVerticleTest.java
@@ -1,6 +1,8 @@
 package org.folio.edge.patron;
 
+import static junit.framework.TestCase.assertTrue;
 import static org.folio.edge.core.Constants.APPLICATION_JSON;
+import static org.folio.edge.core.Constants.DAY_IN_MILLIS;
 import static org.folio.edge.core.Constants.SYS_LOG_LEVEL;
 import static org.folio.edge.core.Constants.SYS_OKAPI_URL;
 import static org.folio.edge.core.Constants.SYS_PORT;
@@ -10,6 +12,7 @@ import static org.folio.edge.core.Constants.TEXT_PLAIN;
 import static org.folio.edge.core.utils.test.MockOkapi.X_DURATION;
 import static org.folio.edge.patron.Constants.MSG_ACCESS_DENIED;
 import static org.folio.edge.patron.Constants.MSG_REQUEST_TIMEOUT;
+import static org.folio.edge.patron.utils.PatronMockOkapi.holdReqTs;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
@@ -18,7 +21,9 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
 import java.io.IOException;
+import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.UUID;
 
@@ -678,7 +683,7 @@ public class MainVerticleTest {
   public void testPlaceItemHoldSuccess(TestContext context) throws Exception {
     logger.info("=== Test successful item hold ===");
 
-    Hold hold = PatronMockOkapi.getHold(itemId);
+    Hold hold = PatronMockOkapi.getHold(itemId, new Date(holdReqTs));
 
     final Response resp = RestAssured
       .with()
@@ -694,8 +699,30 @@ public class MainVerticleTest {
 
     Hold expected = Hold.fromJson(PatronMockOkapi.getPlacedHoldJson(hold));
     Hold actual = Hold.fromJson(resp.body().asString());
+    validateHolds(expected, actual);
+  }
 
-    assertEquals(expected, actual);
+  @Test
+  public void testPlaceItemHoldWithoutRequestDateSuccess(TestContext context) throws Exception {
+    logger.info("=== Test successful item hold ===");
+
+    Hold hold = PatronMockOkapi.getHold(itemId, null);
+
+    final Response resp = RestAssured
+      .with()
+      .body(hold.toJson())
+      .contentType(APPLICATION_JSON)
+      .post(
+        String.format("/patron/account/%s/item/%s/hold?apikey=%s", patronId, itemId, apiKey))
+      .then()
+      .statusCode(201)
+      .header(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON)
+      .extract()
+      .response();
+
+    Hold expected = Hold.fromJson(PatronMockOkapi.getPlacedHoldJson(hold));
+    Hold actual = Hold.fromJson(resp.body().asString());
+    validateHolds(expected, actual);
   }
 
   @Test
@@ -1149,4 +1176,26 @@ public class MainVerticleTest {
     verify(mockOkapi).loginHandler(any());
     verify(mockOkapi, atLeast(iters)).getAccountHandler(any());
   }
+
+  private void validateHolds(Hold expectedHolds, Hold actualHolds) {
+    assertEquals(expectedHolds.requestId, actualHolds.requestId);
+    assertEquals(expectedHolds.pickupLocationId, actualHolds.pickupLocationId);
+    assertEquals(expectedHolds.queuePosition, actualHolds.queuePosition);
+    assertEquals(expectedHolds.expirationDate, actualHolds.expirationDate);
+    assertEquals(expectedHolds.status, actualHolds.status);
+    assertEquals(expectedHolds.item, actualHolds.item);
+
+    long expectedRequestDateTs = expectedHolds.requestDate != null
+      //have to add 1 day's milliseconds because the Request timestamp is 1 day in the past
+      ? expectedHolds.requestDate.getTime() + DAY_IN_MILLIS
+      : Instant.now().toEpochMilli();
+
+    long actualRequestDateTs = actualHolds.requestDate != null
+      ? actualHolds.requestDate.getTime()
+      : Instant.now().toEpochMilli();
+
+    //check that the actual timestamp is within a minute of the expected timestamp
+    assertTrue((actualRequestDateTs - expectedRequestDateTs)/1000 < 60);
+  }
 }
+

--- a/src/test/java/org/folio/edge/patron/utils/PatronMockOkapi.java
+++ b/src/test/java/org/folio/edge/patron/utils/PatronMockOkapi.java
@@ -415,6 +415,18 @@ public class PatronMockOkapi extends MockOkapi {
       .build();
   }
 
+  public static Hold getHold(String itemId, Date holdReqDate) {
+    return Hold.builder()
+      .item(getItem(itemId))
+      .pickupLocationId(pickupLocationId)
+      .expirationDate(new Date(holdExpTs))
+      .queuePosition(2)
+      .requestDate(holdReqDate)
+      .requestId(holdReqId)
+      .status(Status.OPEN_NOT_YET_FILLED)
+      .build();
+  }
+
   public static Charge getCharge(String itemId) {
     return Charge.builder()
       .item(getItem(itemId_overdue))


### PR DESCRIPTION
**Approach**
- Make requestDate optional
- For both instance- and item-level requests, replace the incoming requestDate with the timestamp, and if there isn't a requestDate in the JSON request, add the new requestDate element to send to mod-patron.
- Because the timestamp is in UTC and it can't be injected into the code at runtime, the unit tests need to compare the timestamps interval (within one minute).
- There isn't a need to do anything for request expiration date.  The expiration date is already not required, will only be populated if the client passes in, and only returned to the client if there's a value for it (set by the client).