### PR TITLE
Edgpatron-19: Expiration Date

### DIFF
--- a/src/main/java/org/folio/edge/patron/Constants.java
+++ b/src/main/java/org/folio/edge/patron/Constants.java
@@ -26,6 +26,9 @@ public class Constants {
   public static final String MSG_REQUEST_TIMEOUT = "Request to FOLIO timed out";
   public static final String MSG_NOT_IMPLEMENTED = "Not Implemented";
 
+  public static final String FIELD_EXPIRATION_DATE = "expirationDate";
+  public static final String FIELD_REQUEST_DATE = "requestDate";
+
   private Constants() {
 
   }

--- a/src/main/java/org/folio/edge/patron/PatronHandler.java
+++ b/src/main/java/org/folio/edge/patron/PatronHandler.java
@@ -334,7 +334,7 @@ public class PatronHandler extends Handler {
       }
     } catch (Exception parseEx) {
       logger.debug("Exception parsing request expirationDate: " + requestExpirationDate);
-      requestMessage.putNull(FIELD_EXPIRATION_DATE);
+      requestMessage.remove(FIELD_EXPIRATION_DATE);
     }
     return requestMessage;
   }

--- a/src/test/java/org/folio/edge/patron/MainVerticleTest.java
+++ b/src/test/java/org/folio/edge/patron/MainVerticleTest.java
@@ -1258,14 +1258,7 @@ public class MainVerticleTest {
   }
 
   private String swapExpirationDate(String jsonRequestMessage, String dateString) {
-    final String regex = "(?<=\"expirationDate\").*\".*\"";
-    final Pattern pattern = Pattern.compile(regex);
-    final Matcher matcher = pattern.matcher(jsonRequestMessage);
-
-    if (matcher.find()) {
-      jsonRequestMessage = jsonRequestMessage.replaceAll("(?<=\"expirationDate\").*\".*\"", dateString);
-    }
-    return jsonRequestMessage;
+    return jsonRequestMessage.replaceFirst("(?<=\"expirationDate\").*\".*\"", dateString);
   }
 }
 


### PR DESCRIPTION
Remove expirationDate from request (not passing it on to mod-patron) when it's proved to be invalid by attempting to parse the dateTime string into a **Date** object.

In the test, there is no simple way to create a Hold object that has an invalid Date object to call the RestAssured service, so I had to create a Hold object with a valid Date object first, then convert it to a string and use regular expression to swap out the date value to something invalid. 