### PR TITLE
EDGEPATRON-27: Remove validation for canceledByUserId 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.folio</groupId>
   <artifactId>edge-patron</artifactId>
-  <version>4.0.0</version>
+  <version>4.1.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Edge API - Patron Empowerment</name>
@@ -17,7 +17,7 @@
     <url>https://github.com/folio-org/edge-patron.git</url>
     <connection>scm:git:git://github.com/folio-org/edge-paton.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/edge-patron.git</developerConnection>
-    <tag>v4.0.0</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <licenses>

--- a/src/main/java/org/folio/edge/patron/Constants.java
+++ b/src/main/java/org/folio/edge/patron/Constants.java
@@ -32,12 +32,9 @@ public class Constants {
 
   public static final String FIELD_HOLD_ID = "holdId";
   public static final String FIELD_CANCELLATION_REASON_ID = "cancellationReasonId";
-  public static final String FIELD_CANCELED_BY_USER_ID = "canceledByUserId";
   public static final String FIELD_CANCELLATION_ADDITIONAL_INFO = "cancellationAdditionalInformation";
   public static final String FIELD_CANCELED_DATE = "canceledDate";
 
   private Constants() {
-
   }
-
 }

--- a/src/main/java/org/folio/edge/patron/model/HoldCancellationValidator.java
+++ b/src/main/java/org/folio/edge/patron/model/HoldCancellationValidator.java
@@ -4,7 +4,6 @@ import io.vertx.core.json.JsonObject;
 
 import java.util.UUID;
 
-import static org.folio.edge.patron.Constants.FIELD_CANCELED_BY_USER_ID;
 import static org.folio.edge.patron.Constants.FIELD_CANCELLATION_REASON_ID;
 import static org.folio.edge.patron.Constants.FIELD_HOLD_ID;
 
@@ -16,9 +15,9 @@ public class HoldCancellationValidator {
     String errorMessage = null;
     try {
       if (validateRequiredHoldCancellationFields(holdCancellationRequest)) {
-        errorMessage = "required fields for cancelling holds are missing (holdId, cancellationReasonId, canceledByUserId)";
+        errorMessage = "required fields for cancelling holds are missing (holdId, cancellationReasonId)";
       } else if (areRequiredHoldCancellationFieldsUUIDs(holdCancellationRequest)) {
-        errorMessage = "invalid values for one of the required fields (holdId, cancellationReasonId, canceledByUserId)";
+        errorMessage = "invalid values for one of the required fields (holdId, cancellationReasonId)";
       }
     } catch (Exception e) {
       errorMessage = "invalid holdCancellationRequest. " + e.getMessage();
@@ -28,15 +27,13 @@ public class HoldCancellationValidator {
 
   private static boolean validateRequiredHoldCancellationFields(JsonObject holdCancellation) {
     return (isNullOrEmpty(holdCancellation.getString(FIELD_HOLD_ID)) ||
-      isNullOrEmpty(holdCancellation.getString(FIELD_CANCELLATION_REASON_ID))||
-      isNullOrEmpty(holdCancellation.getString(FIELD_CANCELED_BY_USER_ID))
+      isNullOrEmpty(holdCancellation.getString(FIELD_CANCELLATION_REASON_ID))
     );
   }
 
   private static boolean areRequiredHoldCancellationFieldsUUIDs(JsonObject holdCancellation) {
     return (!isUUID (holdCancellation.getString(FIELD_HOLD_ID)) ||
-      !isUUID (holdCancellation.getString(FIELD_CANCELLATION_REASON_ID)) ||
-      !isUUID (holdCancellation.getString(FIELD_CANCELED_BY_USER_ID))
+      !isUUID (holdCancellation.getString(FIELD_CANCELLATION_REASON_ID))
     );
   }
 

--- a/src/main/java/org/folio/edge/patron/utils/PatronOkapiClient.java
+++ b/src/main/java/org/folio/edge/patron/utils/PatronOkapiClient.java
@@ -15,7 +15,6 @@ import org.folio.edge.patron.model.Hold;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 
-import static org.folio.edge.patron.Constants.FIELD_CANCELED_BY_USER_ID;
 import static org.folio.edge.patron.Constants.FIELD_CANCELED_DATE;
 import static org.folio.edge.patron.Constants.FIELD_CANCELLATION_ADDITIONAL_INFO;
 import static org.folio.edge.patron.Constants.FIELD_CANCELLATION_REASON_ID;
@@ -143,7 +142,6 @@ public class PatronOkapiClient extends OkapiClient {
 
   public void cancelHold(String patronId, String holdId, JsonObject holdCancellationRequest, MultiMap headers,
       Handler<HttpClientResponse> responseHandler, Handler<Throwable> exceptionHandler) {
-
     getRequest(holdId,
       headers,
       resp -> {
@@ -152,7 +150,7 @@ public class PatronOkapiClient extends OkapiClient {
             String bodyStr = body.toString();
             try {
               JsonObject requestToCancel = new JsonObject(bodyStr);
-              Hold holdEntity = createCancellationHoldRequest(holdCancellationRequest, requestToCancel);
+              Hold holdEntity = createCancellationHoldRequest(holdCancellationRequest, requestToCancel, patronId);
               post(
                 String.format("%s/patron/account/%s/hold/%s/cancel", okapiURL, patronId, holdId),
                 tenant,
@@ -212,10 +210,10 @@ public class PatronOkapiClient extends OkapiClient {
         exceptionHandler);
   }
 
-  private Hold createCancellationHoldRequest(JsonObject cancellationRequest, JsonObject baseRequest) {
+  private Hold createCancellationHoldRequest(JsonObject cancellationRequest, JsonObject baseRequest, String patronId) {
     return Hold.builder()
       .cancellationReasonId(cancellationRequest.getString(FIELD_CANCELLATION_REASON_ID))
-      .canceledByUserId(cancellationRequest.getString(FIELD_CANCELED_BY_USER_ID))
+      .canceledByUserId(patronId)
       .cancellationAdditionalInformation(cancellationRequest.getString(FIELD_CANCELLATION_ADDITIONAL_INFO))
       .canceledDate(new DateTime(cancellationRequest.getString(FIELD_CANCELED_DATE), DateTimeZone.UTC).toDate())
       .requestId(baseRequest.getString("id"))

--- a/src/test/java/org/folio/edge/patron/MainVerticleTest.java
+++ b/src/test/java/org/folio/edge/patron/MainVerticleTest.java
@@ -946,7 +946,7 @@ public class MainVerticleTest {
     int statusCode = 422;
 
     String cancedHoldJson = PatronMockOkapi.getInvalidHoldCancellation(invalidHoldCancellationdHoldId);
-    String coreMessage = "required fields for cancelling holds are missing (holdId, cancellationReasonId, canceledByUserId)";
+    String coreMessage = "required fields for cancelling holds are missing (holdId, cancellationReasonId)";
 
     final Response resp = RestAssured
       .with()

--- a/src/test/java/org/folio/edge/patron/MainVerticleTest.java
+++ b/src/test/java/org/folio/edge/patron/MainVerticleTest.java
@@ -16,6 +16,7 @@ import static org.folio.edge.patron.utils.PatronMockOkapi.holdReqId_notFound;
 import static org.folio.edge.patron.utils.PatronMockOkapi.holdReqTs;
 import static org.folio.edge.patron.utils.PatronMockOkapi.invalidHoldCancellationdHoldId;
 import static org.folio.edge.patron.utils.PatronMockOkapi.malformedHoldCancellationHoldId;
+import static org.folio.edge.patron.utils.PatronMockOkapi.nonUUIDHoldCanceledByPatronId;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -916,7 +917,7 @@ public class MainVerticleTest {
   public void testCancelHoldSuccess(TestContext context) throws Exception {
     logger.info("=== Test cancel hold success ===");
 
-    String cancedHoldJson = PatronMockOkapi.getHoldCancellation(holdCancellationHoldId);
+    String cancedHoldJson = PatronMockOkapi.getHoldCancellation(holdCancellationHoldId, patronId);
 
     final Response resp = RestAssured
       .with()
@@ -935,9 +936,40 @@ public class MainVerticleTest {
 
     assertEquals(expected, actual);
     assertEquals(holdCancellationHoldId, expected.requestId);
-    assertEquals(PatronMockOkapi.holdCancelationReasonId, actual.cancellationReasonId);
+    assertEquals(PatronMockOkapi.holdCancellationReasonId, actual.cancellationReasonId);
     assertEquals(Hold.Status.CLOSED_CANCELED, actual.status);
     assertEquals(0, actual.queuePosition);
+    assertEquals(expected.canceledByUserId, actual.canceledByUserId);
+  }
+
+  @Test
+  public void testCancelHoldSuccessWithNonUUIDCanceledById(TestContext context) throws Exception {
+    logger.info("=== Test cancel hold success ===");
+
+    String cancedHoldJson = PatronMockOkapi.getHoldCancellation(
+                                holdCancellationHoldId,
+                                nonUUIDHoldCanceledByPatronId);
+
+    final Response resp = RestAssured
+      .with()
+      .contentType(APPLICATION_JSON)
+      .body(cancedHoldJson)
+      .post(
+        String.format("/patron/account/%s/hold/%s/cancel?apikey=%s", patronId, holdCancellationHoldId, apiKey))
+      .then()
+      .statusCode(200)
+      .header(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON)
+      .extract()
+      .response();
+
+    Hold expected = Hold.fromJson(PatronMockOkapi.getRemovedHoldJson(holdCancellationHoldId));
+    Hold actual = Hold.fromJson(resp.body().asString());
+
+    assertEquals(expected.requestId, actual.requestId);
+    assertEquals(PatronMockOkapi.holdCancellationReasonId, actual.cancellationReasonId);
+    assertEquals(Hold.Status.CLOSED_CANCELED, actual.status);
+    assertEquals(0, actual.queuePosition);
+    assertEquals(expected.canceledByUserId, actual.canceledByUserId);
   }
 
   @Test
@@ -970,7 +1002,7 @@ public class MainVerticleTest {
   public void testCancelHoldPatronNotFound(TestContext context) throws Exception {
     logger.info("=== Test cancel hold w/ patron not found ===");
     int statusCode = 404;
-    String cancedHoldJson = PatronMockOkapi.getHoldCancellation(holdCancellationHoldId);
+    String cancedHoldJson = PatronMockOkapi.getHoldCancellation(holdCancellationHoldId, PatronMockOkapi.extPatronId_notFound);
 
     final Response resp = RestAssured
       .with()
@@ -996,7 +1028,7 @@ public class MainVerticleTest {
 
     int expectedStatusCode = 404;
     String expectedErrorMessage = "request record with ID \"" + PatronMockOkapi.holdReqId_notFound  + "\" cannot be found";
-    String cancedHoldJson = PatronMockOkapi.getHoldCancellation(holdReqId_notFound);
+    String cancedHoldJson = PatronMockOkapi.getHoldCancellation(holdReqId_notFound,extPatronId);
 
     final Response resp = RestAssured
       .with()
@@ -1022,7 +1054,7 @@ public class MainVerticleTest {
     logger.info("=== Test cancel hold with unknown apiKey (tenant) ===");
 
     int expectedStatusCode = 401;
-    String cancedHoldJson = PatronMockOkapi.getHoldCancellation(holdCancellationHoldId);
+    String cancedHoldJson = PatronMockOkapi.getHoldCancellation(holdCancellationHoldId, extPatronId);
 
     final Response resp = RestAssured
       .with()
@@ -1050,7 +1082,7 @@ public class MainVerticleTest {
     logger.info("=== Test cancel hold with malformed apiKey ===");
 
     int expectedStatusCode = 401;
-    String cancedHoldJson = PatronMockOkapi.getHoldCancellation(holdCancellationHoldId);
+    String cancedHoldJson = PatronMockOkapi.getHoldCancellation(holdCancellationHoldId, extPatronId);
 
     final Response resp = RestAssured
       .with()
@@ -1079,7 +1111,7 @@ public class MainVerticleTest {
     logger.info("=== Test cancel hold request timeout ===");
     int expectedStatusCode = 408;
 
-    String cancedHoldJson = PatronMockOkapi.getHoldCancellation(holdCancellationHoldId);
+    String cancedHoldJson = PatronMockOkapi.getHoldCancellation(holdCancellationHoldId, extPatronId);
 
     final Response resp = RestAssured
       .with()
@@ -1104,7 +1136,7 @@ public class MainVerticleTest {
   public void testCancelHoldWithMalformedJsonRequest(TestContext context) throws Exception {
     logger.info("=== Test cancel hold with malformed JSON Request (from mod-circ) ===");
 
-    String cancedHoldJson = PatronMockOkapi.getHoldCancellation(malformedHoldCancellationHoldId);
+    String cancedHoldJson = PatronMockOkapi.getHoldCancellation(malformedHoldCancellationHoldId, patronId);
 
     final Response resp = RestAssured
       .with()
@@ -1126,7 +1158,7 @@ public class MainVerticleTest {
     logger.info("=== Test edit hold w/ patron not found ===");
 
     int expectedStatusCode = 404;
-    String canceledHold = PatronMockOkapi.getHoldCancellation(holdCancellationHoldId);
+    String canceledHold = PatronMockOkapi.getHoldCancellation(holdCancellationHoldId, PatronMockOkapi.extPatronId_notFound);
 
     final Response resp = RestAssured
       .with()
@@ -1152,7 +1184,7 @@ public class MainVerticleTest {
     logger.info("=== Test edit hold w/hold not found ===");
     int expectedStatusCode = 404;
     String expectedErrorMsg = "request record with ID \"" + holdReqId_notFound + "\" cannot be found";
-    String canceledHold = PatronMockOkapi.getHoldCancellation(holdReqId_notFound);
+    String canceledHold = PatronMockOkapi.getHoldCancellation(holdReqId_notFound, extPatronId);
 
     final Response resp = RestAssured
       .with()
@@ -1177,7 +1209,7 @@ public class MainVerticleTest {
     logger.info("=== Test edit hold with unknown apiKey (tenant) ===");
 
     int expectedStatusCode = 401;
-    String canceledHold = PatronMockOkapi.getHoldCancellation(holdReqId_notFound);
+    String canceledHold = PatronMockOkapi.getHoldCancellation(holdReqId_notFound, extPatronId);
 
     final Response resp = RestAssured
       .with()
@@ -1202,7 +1234,7 @@ public class MainVerticleTest {
     logger.info("=== Test edit hold with malformed apiKey ===");
 
     int expectedStatusCode = 401;
-    String canceledHold = PatronMockOkapi.getHoldCancellation(holdReqId_notFound);
+    String canceledHold = PatronMockOkapi.getHoldCancellation(holdReqId_notFound, extPatronId);
 
     final Response resp = RestAssured
       .with()
@@ -1226,7 +1258,7 @@ public class MainVerticleTest {
     logger.info("=== Test edit hold request timeout ===");
 
     int expectedStatusCode = 408;
-    String canceledHold = PatronMockOkapi.getHoldCancellation(holdReqId_notFound);
+    String canceledHold = PatronMockOkapi.getHoldCancellation(holdReqId_notFound, extPatronId);
 
     final Response resp = RestAssured
       .with()

--- a/src/test/java/org/folio/edge/patron/model/HoldCancellationValidatorTest.java
+++ b/src/test/java/org/folio/edge/patron/model/HoldCancellationValidatorTest.java
@@ -18,27 +18,16 @@ public class HoldCancellationValidatorTest {
 
   @Test
   public void validateRequiredHoldMissingCancellationFields() {
-    String expectedErrorMsg = "required fields for cancelling holds are missing (holdId, cancellationReasonId, canceledByUserId)";
+    String expectedErrorMsg = "required fields for cancelling holds are missing (holdId, cancellationReasonId)";
     String cancellationJsonMissingHoldId = "{" +
-      "\"canceledByUserId\" : \"" + UUID.randomUUID().toString() + "\"," +
       "\"cancellationReasonId\" : \"" + UUID.randomUUID().toString() + "\"," +
       "\"cancellationAdditionalInformation\" : \"blablabla\"" +
       "}";
     String result = HoldCancellationValidator.validateCancelHoldRequest(new JsonObject(cancellationJsonMissingHoldId));
     assertEquals(expectedErrorMsg, result);
 
-    String cancellationJsonMissingCanceledByUserId= "{" +
-      "\"holdId\" :  \"" + UUID.randomUUID().toString() + "\"," +
-      "\"canceledByUserId\" : \"\"," +
-      "\"cancellationReasonId\" : \"" + UUID.randomUUID().toString() + "\"," +
-      "\"cancellationAdditionalInformation\" : \"blablabla\"" +
-      "}";
-    result = HoldCancellationValidator.validateCancelHoldRequest(new JsonObject(cancellationJsonMissingCanceledByUserId));
-    assertEquals(expectedErrorMsg, result);
-
     String cancellationJsonMissingcancellationReasonId= "{" +
       "\"holdId\" :  \"" + UUID.randomUUID().toString() + "\"," +
-      "\"canceledByUserId\" : \"" + UUID.randomUUID().toString() + "\"," +
       "\"cancellationAdditionalInformation\" : \"blablabla\"" +
       "}";
     result = HoldCancellationValidator.validateCancelHoldRequest(new JsonObject(cancellationJsonMissingcancellationReasonId));
@@ -53,25 +42,14 @@ public class HoldCancellationValidatorTest {
 
     String invalidHoldId = "{" +
     "\"holdId\" : \"" + invalidUUID + "\"," +
-    "\"canceledByUserId\" : \"" + validUUID + "\"," +
       "\"cancellationReasonId\" : \"" + validUUID + "\"," +
     "\"cancellationAdditionalInformation\" : \"blablabla\"" +
     "}";
     String result = HoldCancellationValidator.validateCancelHoldRequest(new JsonObject(invalidHoldId));
     assertEquals(expectedErrorMsg, result);
 
-    String invalidCanceledByUserId = "{" +
-      "\"holdId\" : \"" + validUUID + "\"," +
-      "\"canceledByUserId\" : \"" + invalidUUID + "\"," +
-      "\"cancellationReasonId\" : \"" + validUUID + "\"," +
-      "\"cancellationAdditionalInformation\" : \"blablabla\"" +
-      "}";
-    result = HoldCancellationValidator.validateCancelHoldRequest(new JsonObject(invalidCanceledByUserId));
-    assertEquals(expectedErrorMsg, result);
-
     String invalidCancellationReasonId = "{" +
       "\"holdId\" : \"" + validUUID + "\"," +
-      "\"canceledByUserId\" : \"" + validUUID + "\"," +
       "\"cancellationReasonId\" : \"" + invalidUUID + "\"," +
       "\"cancellationAdditionalInformation\" : \"blablabla\"" +
       "}";
@@ -83,7 +61,6 @@ public class HoldCancellationValidatorTest {
   public void validateCancelHoldRequestValidParams() {
     String cancellationJson = "{" +
       "\"holdId\" : \"" + UUID.randomUUID().toString() + "\"," +
-      "\"canceledByUserId\" : \"" + UUID.randomUUID().toString() + "\"," +
       "\"cancellationReasonId\" : \"" + UUID.randomUUID().toString() + "\"," +
       "\"cancellationAdditionalInformation\" : \"blablabla\"," +
       "\"canceledDate\" : \"2019-12-06T16:05:16.2165Z\"" +

--- a/src/test/java/org/folio/edge/patron/model/HoldCancellationValidatorTest.java
+++ b/src/test/java/org/folio/edge/patron/model/HoldCancellationValidatorTest.java
@@ -38,7 +38,7 @@ public class HoldCancellationValidatorTest {
   public void validateCancelHoldInvalidUUIDs() {
     String validUUID = "3a40852d-49fd-4df2-a1f9-6e2641a6e91f";
     String invalidUUID = "3a40852d-g9fd-fdf2-a1f9-6e2641a6e91p";
-    String expectedErrorMsg = "invalid values for one of the required fields (holdId, cancellationReasonId, canceledByUserId)";
+    String expectedErrorMsg = "invalid values for one of the required fields (holdId, cancellationReasonId)";
 
     String invalidHoldId = "{" +
     "\"holdId\" : \"" + invalidUUID + "\"," +

--- a/src/test/java/org/folio/edge/patron/utils/PatronMockOkapi.java
+++ b/src/test/java/org/folio/edge/patron/utils/PatronMockOkapi.java
@@ -66,11 +66,12 @@ public class PatronMockOkapi extends MockOkapi {
   public static final String itemId_reached_max_renewals = UUID.randomUUID().toString();
   public static final String itemId_reached_max_renewals_empty_error_msg = UUID.randomUUID().toString();
   public static final String itemId_reached_max_renewals_bad_json_msg = UUID.randomUUID().toString();
-  public static final String holdCancelationReasonId = UUID.randomUUID().toString();
+  public static final String holdCancellationReasonId = UUID.randomUUID().toString();
   public static final String holdCancellationHoldId = "6b6b715e-8038-49ba-ab91-faa8fdf7449c";
   public static final String invalidHoldCancellationdHoldId = UUID.randomUUID().toString();
   public static final String malformedHoldCancellationHoldId = "6b6b715e-8038-49ba-ab91-faa8fdf7448d";
   public static final String goodRequestId = holdCancellationHoldId ;
+  public static final String nonUUIDHoldCanceledByPatronId = "patron@folio.org";
 
   public static final long checkedOutTs = System.currentTimeMillis() - (34 * DAY_IN_MILLIS);
   public static final long dueDateTs = checkedOutTs + (20 * DAY_IN_MILLIS);
@@ -423,11 +424,13 @@ public class PatronMockOkapi extends MockOkapi {
     Status holdStatus = Status.OPEN_NOT_YET_FILLED;
     int queuePosition = 2;
     String cancellationReasonId = null;
+    String canceledByUserId = null;
 
     if (holdReqId.equals(holdCancellationHoldId)) {
       holdStatus = Status.CLOSED_CANCELED;
       queuePosition = 0;
-      cancellationReasonId = holdCancelationReasonId;
+      cancellationReasonId = holdCancellationReasonId;
+      canceledByUserId = patronId;
     }
 
     return Hold.builder()
@@ -439,6 +442,7 @@ public class PatronMockOkapi extends MockOkapi {
       .requestId(holdReqId)
       .status(holdStatus)
       .cancellationReasonId(cancellationReasonId)
+      .canceledByUserId(canceledByUserId)
       .build();
   }
 
@@ -500,11 +504,10 @@ public class PatronMockOkapi extends MockOkapi {
     return ret;
   }
 
-  public static String getRemovedHoldJson(String itemId) {
-
+  public static String getRemovedHoldJson(String holdReqId) {
     String ret = null;
     try {
-      Hold hold = getHold(itemId);
+      Hold hold = getHold(holdReqId);
       ret = hold.toJson();
     } catch (JsonProcessingException e) {
       logger.warn("Failed to generate Hold JSON", e);
@@ -512,7 +515,7 @@ public class PatronMockOkapi extends MockOkapi {
     return ret;
   }
 
-  public static String getHoldCancellation(String holdId) {
+  public static String getHoldCancellation(String holdId, String canceledByUserId) {
     String ret = null;
     try {
 
@@ -522,8 +525,9 @@ public class PatronMockOkapi extends MockOkapi {
       HoldCancellation cancellation =  HoldCancellation.builder()
         .holdId(holdId)
         .canceledDate(canceledDate)
-        .cancellationReasonId(holdCancelationReasonId)
+        .cancellationReasonId(holdCancellationReasonId)
         .cancellationAdditionalInformation("I don't want it anymore")
+        .canceledByUserId(canceledByUserId)
         .build();
       ret = cancellation.toJson();
     } catch (JsonProcessingException | ParseException e) {

--- a/src/test/java/org/folio/edge/patron/utils/PatronMockOkapi.java
+++ b/src/test/java/org/folio/edge/patron/utils/PatronMockOkapi.java
@@ -67,7 +67,6 @@ public class PatronMockOkapi extends MockOkapi {
   public static final String itemId_reached_max_renewals_empty_error_msg = UUID.randomUUID().toString();
   public static final String itemId_reached_max_renewals_bad_json_msg = UUID.randomUUID().toString();
   public static final String holdCancelationReasonId = UUID.randomUUID().toString();
-  public static final String holdCanceledByUserId = UUID.randomUUID().toString();
   public static final String holdCancellationHoldId = "6b6b715e-8038-49ba-ab91-faa8fdf7449c";
   public static final String invalidHoldCancellationdHoldId = UUID.randomUUID().toString();
   public static final String malformedHoldCancellationHoldId = "6b6b715e-8038-49ba-ab91-faa8fdf7448d";
@@ -525,7 +524,6 @@ public class PatronMockOkapi extends MockOkapi {
         .canceledDate(canceledDate)
         .cancellationReasonId(holdCancelationReasonId)
         .cancellationAdditionalInformation("I don't want it anymore")
-        .canceledByUserId(holdCanceledByUserId)
         .build();
       ret = cancellation.toJson();
     } catch (JsonProcessingException | ParseException e) {
@@ -546,7 +544,6 @@ public class PatronMockOkapi extends MockOkapi {
         .canceledDate(canceledDate)
         .cancellationReasonId(null)
         .cancellationAdditionalInformation("I don't want it anymore")
-        .canceledByUserId("")
         .build();
       ret = cancellation.toJson();
     } catch (JsonProcessingException | ParseException e) {

--- a/src/test/java/org/folio/edge/patron/utils/PatronOkapiClientTest.java
+++ b/src/test/java/org/folio/edge/patron/utils/PatronOkapiClientTest.java
@@ -392,7 +392,7 @@ public class PatronOkapiClientTest {
     logger.info("=== Test cancel hold successfully ===");
 
     Hold hold = PatronMockOkapi.getHold(PatronMockOkapi.holdCancellationHoldId);
-    String holdCancellation = PatronMockOkapi.getHoldCancellation(hold.requestId);
+    String holdCancellation = PatronMockOkapi.getHoldCancellation(hold.requestId, patronId);
 
     Async async = context.async();
     client.login("admin", "password").thenAcceptAsync(v -> {
@@ -427,7 +427,7 @@ public class PatronOkapiClientTest {
       assertEquals(MOCK_TOKEN, client.getToken());
       client.cancelHold(PatronMockOkapi.patronId_notFound,
           hold.requestId,
-          new JsonObject(PatronMockOkapi.getHoldCancellation(hold.requestId)),
+          new JsonObject(PatronMockOkapi.getHoldCancellation(hold.requestId, PatronMockOkapi.patronId_notFound)),
           resp -> resp.bodyHandler(body -> {
             logger.info("mod-patron response body: " + body);
             context.assertEquals(404, resp.statusCode());
@@ -448,7 +448,7 @@ public class PatronOkapiClientTest {
       assertEquals(MOCK_TOKEN, client.getToken());
       client.cancelHold(patronId,
           PatronMockOkapi.holdReqId_notFound,
-          new JsonObject(PatronMockOkapi.getHoldCancellation(PatronMockOkapi.holdReqId_notFound)),
+          new JsonObject(PatronMockOkapi.getHoldCancellation(PatronMockOkapi.holdReqId_notFound, patronId)),
           resp -> resp.bodyHandler(body -> {
             logger.info("mod-patron response body: " + body);
             context.assertEquals(404, resp.statusCode());


### PR DESCRIPTION
Removed validation of the property canceledByUserId.
Updated tests to remove references to canceledByUserId.

It turns out that the validation code was the only place that makes use of canceledByUserId. It seems like the patronId that is eventually passed on to mod-patron for canceledByUserId is being extracted from the normal way by edge-common.