### PR TITLE
Update dependencies for patron comments EDGPATRON-33

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -5,7 +5,7 @@
   "requires": [
     {
       "id": "patron",
-      "version": "4.1"
+      "version": "4.2"
     },
     {
       "id": "login",

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -8,6 +8,10 @@
       "version": "4.2"
     },
     {
+      "id": "circulation",
+      "version": "9.5"
+    },
+    {
       "id": "login",
       "version": "5.0 6.0 7.0"
     }


### PR DESCRIPTION
Whilst trying to release `edge-patron` it became apparent that the dependencies might be incorrect.

This module makes requests to `/circulation/requests/{id}` endpoints meaning it needs to depend upon the `circulation` interface. I chose the same version that `mod-patron` [depends](https://github.com/folio-org/mod-patron/blob/e343d663d8d805d3b1250147137888fdaee955f4/descriptors/ModuleDescriptor-template.json#L68) upon for simplicity.

This module also expects the `patronComments` property for requests and that was introduced into the `patron` interface in [version 4.2](https://github.com/folio-org/mod-patron/pull/48/files) and so I have updated these to match as well.