### PR TITLE
Changing RAML file to reflect use of externalSystemID

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## 4.7.0 IN-PROGRESS
+
+Removed UUID string pattern from RAML file, as module now uses externalSystemID to look up patron data [EDGPATRON-61] (https://issues.folio.org/browse/EDGPATRON-61)
+
 ## 4.6.0 2021-09-27
 
 * Upgrade to vert.x 4.x [EDGPATRON-39] (https://issues.folio.org/browse/EDGPATRON-39)

--- a/ramls/edge-patron.raml
+++ b/ramls/edge-patron.raml
@@ -30,9 +30,8 @@ types:
       description: Service endpoints that manage accounts by an existing Id
       uriParameters:
         id:
-          description: The UUID of a FOLIO user
+          description: The external system ID of a folio user
           type: string
-          pattern: ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$
       get:
         description: Return account details for the specified FOLIO user id
         queryParameters:

--- a/ramls/edge-patron.raml
+++ b/ramls/edge-patron.raml
@@ -30,7 +30,7 @@ types:
       description: Service endpoints that manage accounts by an existing Id
       uriParameters:
         id:
-          description: The external system ID of a folio user
+          description: Patron's external system Id stored in FOLIO user record.
           type: string
       get:
         description: Return account details for the specified FOLIO user id


### PR DESCRIPTION
The RAML file was erroneously indicating that edge-patron uses 
the UUID of the user.  It instead uses the externalsystemId of the user.

I'm assuming the documentation referenced in this issue is 
auto-generated?  So changing the desc in the RAML file will 
change the online docs?