### PR TITLE
EDGPATRON-61: GET edge-patron documentation needs update

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## 4.7.0 IN-PROGRESS
+
+Removed UUID string pattern from RAML file, as module now uses externalSystemID to look up patron data [EDGPATRON-61] (https://issues.folio.org/browse/EDGPATRON-61)
+
 ## 4.6.0 2021-09-27
 
 * Upgrade to vert.x 4.x [EDGPATRON-39] (https://issues.folio.org/browse/EDGPATRON-39)

--- a/ramls/edge-patron.raml
+++ b/ramls/edge-patron.raml
@@ -30,9 +30,8 @@ types:
       description: Service endpoints that manage accounts by an existing Id
       uriParameters:
         id:
-          description: The UUID of a FOLIO user
+          description: The external system ID of a folio user
           type: string
-          pattern: ^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$
       get:
         description: Return account details for the specified FOLIO user id
         queryParameters:

--- a/ramls/edge-patron.raml
+++ b/ramls/edge-patron.raml
@@ -30,7 +30,7 @@ types:
       description: Service endpoints that manage accounts by an existing Id
       uriParameters:
         id:
-          description: The external system ID of a folio user
+          description: Patron's external system Id stored in FOLIO user record.
           type: string
       get:
         description: Return account details for the specified FOLIO user id


### PR DESCRIPTION
I've modified the RAML file to make it clear that edge-patron uses
externalpatronid rather than UUID.