### PR TITLE
EDGPATRON-62 Add new params to getAcc API

### DIFF
--- a/ramls/edge-patron.raml
+++ b/ramls/edge-patron.raml
@@ -59,6 +59,27 @@ types:
           apikey:
             description: "API Key"
             type: string
+          sortBy:
+            description: |
+              Part of CQL query, indicates the order of records within the lists of holds, charges, loans
+            example: item.title/sort.ascending
+            required: false
+            type: string
+          offset:
+            description: |
+              Skip over a number of elements by specifying an offset value for the query
+            type: integer
+            required: false
+            example: 1
+            minimum: 0
+            maximum: 2147483647
+          limit:
+            description: |
+              Limit the number of elements returned in the response
+            type: integer
+            required: false
+            example: 10
+            maximum: 2147483647
         responses:
           200:
             description: Returns the user account info

--- a/src/main/java/org/folio/edge/patron/Constants.java
+++ b/src/main/java/org/folio/edge/patron/Constants.java
@@ -13,6 +13,9 @@ public class Constants {
   public static final long DEFAULT_NULL_PATRON_ID_CACHE_TTL_MS = 30 * 1000L;
   public static final int DEFAULT_PATRON_ID_CACHE_CAPACITY = 1000;
 
+  public static final String PARAM_SORT_BY = "sortBy";
+  public static final String PARAM_LIMIT = "limit";
+  public static final String PARAM_OFFSET = "offset";
   public static final String PARAM_INCLUDE_LOANS = "includeLoans";
   public static final String PARAM_INCLUDE_CHARGES = "includeCharges";
   public static final String PARAM_INCLUDE_HOLDS = "includeHolds";

--- a/src/main/java/org/folio/edge/patron/PatronHandler.java
+++ b/src/main/java/org/folio/edge/patron/PatronHandler.java
@@ -63,6 +63,20 @@ public class PatronHandler extends Handler {
       return;
     }
 
+    String offsetParam = ctx.request().getParam(PARAM_OFFSET);
+    if (isRequestIntegerParamWrong(offsetParam, true)) {
+      badRequest(ctx, String.format("'offset' parameter is incorrect. parameter value {%s} is not valid: must be "
+        + "an integer, greater than or equal to 0", offsetParam));
+      return;
+    }
+
+    String limitParam = ctx.request().getParam(PARAM_LIMIT); {
+      if (isRequestIntegerParamWrong(limitParam, false)) {
+        badRequest(ctx, String.format("'limit' parameter is incorrect. parameter value {%s} is not valid: must be an integer", limitParam));
+        return;
+      }
+    }
+
     super.handleCommon(ctx, requiredParams, optionalParams, (client, params) -> {
       final PatronOkapiClient patronClient = new PatronOkapiClient(client);
 
@@ -261,6 +275,22 @@ public class PatronHandler extends Handler {
     if (contentType != null && !contentType.equals("")) {
         response.putHeader(HttpHeaders.CONTENT_TYPE, contentType);
     }
+  }
+
+  private boolean isRequestIntegerParamWrong(String paramToValidate, boolean isShouldCheckForNegativity) {
+    if (paramToValidate != null) {
+      try {
+        int paramValue = Integer.parseInt(paramToValidate);
+        if (isShouldCheckForNegativity && paramValue < 0) {
+          return true;
+        }
+      } catch (NumberFormatException nfe) {
+        logger.debug("Exception during validation of query param: " + nfe.getMessage());
+        return true;
+      }
+    }
+
+    return false;
   }
 
   private static String checkDates(JsonObject requestMessage) {

--- a/src/main/java/org/folio/edge/patron/PatronHandler.java
+++ b/src/main/java/org/folio/edge/patron/PatronHandler.java
@@ -12,9 +12,20 @@ import static org.folio.edge.patron.Constants.PARAM_INCLUDE_HOLDS;
 import static org.folio.edge.patron.Constants.PARAM_INCLUDE_LOANS;
 import static org.folio.edge.patron.Constants.PARAM_INSTANCE_ID;
 import static org.folio.edge.patron.Constants.PARAM_ITEM_ID;
+import static org.folio.edge.patron.Constants.PARAM_LIMIT;
+import static org.folio.edge.patron.Constants.PARAM_OFFSET;
 import static org.folio.edge.patron.Constants.PARAM_PATRON_ID;
+import static org.folio.edge.patron.Constants.PARAM_SORT_BY;
 import static org.folio.edge.patron.model.HoldCancellationValidator.validateCancelHoldRequest;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.web.RoutingContext;
+import io.vertx.ext.web.client.HttpResponse;
 import java.text.SimpleDateFormat;
 import java.util.Collections;
 import java.util.Date;
@@ -22,27 +33,17 @@ import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
 import java.util.concurrent.TimeoutException;
-
-import io.vertx.core.json.JsonObject;
-import org.folio.edge.patron.model.error.Error;
-import org.folio.edge.patron.model.error.Errors;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import io.vertx.core.http.HttpServerResponse;
-import io.vertx.core.json.Json;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.edge.core.Handler;
 import org.folio.edge.core.security.SecureStore;
 import org.folio.edge.core.utils.OkapiClient;
+import org.folio.edge.patron.model.error.Error;
 import org.folio.edge.patron.model.error.ErrorMessage;
+import org.folio.edge.patron.model.error.Errors;
 import org.folio.edge.patron.utils.PatronIdHelper;
 import org.folio.edge.patron.utils.PatronOkapiClient;
 import org.folio.edge.patron.utils.PatronOkapiClientFactory;
-import io.vertx.core.buffer.Buffer;
-import io.vertx.ext.web.client.HttpResponse;
-
-import io.vertx.core.http.HttpHeaders;
-import io.vertx.ext.web.RoutingContext;
 
 public class PatronHandler extends Handler {
 
@@ -84,16 +85,23 @@ public class PatronHandler extends Handler {
   public void handleGetAccount(RoutingContext ctx) {
     handleCommon(ctx,
         new String[] {},
-        new String[] { PARAM_INCLUDE_LOANS, PARAM_INCLUDE_CHARGES, PARAM_INCLUDE_HOLDS },
+        new String[]{PARAM_INCLUDE_LOANS, PARAM_INCLUDE_CHARGES, PARAM_INCLUDE_HOLDS, PARAM_SORT_BY, PARAM_LIMIT,
+        PARAM_OFFSET},
         (client, params) -> {
           boolean includeLoans = Boolean.parseBoolean(params.get(PARAM_INCLUDE_LOANS));
           boolean includeCharges = Boolean.parseBoolean(params.get(PARAM_INCLUDE_CHARGES));
           boolean includeHolds = Boolean.parseBoolean(params.get(PARAM_INCLUDE_HOLDS));
+          String sortBy = params.get(PARAM_SORT_BY);
+          String limit = params.get(PARAM_LIMIT);
+          String offset = params.get(PARAM_OFFSET);
 
           ((PatronOkapiClient) client).getAccount(params.get(PARAM_PATRON_ID),
               includeLoans,
               includeCharges,
               includeHolds,
+              sortBy,
+              limit,
+              offset,
               ctx.request().headers(),
               resp -> handleProxyResponse(ctx, resp),
               t -> handleProxyException(ctx, t));

--- a/src/main/java/org/folio/edge/patron/utils/PatronOkapiClient.java
+++ b/src/main/java/org/folio/edge/patron/utils/PatronOkapiClient.java
@@ -74,21 +74,33 @@ public class PatronOkapiClient extends OkapiClient {
   }
 
   public void getAccount(String patronId, boolean includeLoans, boolean includeCharges,
-      boolean includeHolds, Handler<HttpResponse<Buffer>> responseHandler,
+      boolean includeHolds, String sortBy, String limit, String offset, Handler<HttpResponse<Buffer>> responseHandler,
       Handler<Throwable> exceptionHandler) {
-    getAccount(patronId, includeLoans, includeCharges, includeHolds, null, responseHandler, exceptionHandler);
+    getAccount(patronId, includeLoans, includeCharges, includeHolds, sortBy, limit, offset, null,
+      responseHandler, exceptionHandler);
   }
 
-  public void getAccount(String patronId, boolean includeLoans, boolean includeCharges,
-      boolean includeHolds, MultiMap headers, Handler<HttpResponse<Buffer>> responseHandler,
+  public void getAccount(String patronId, boolean includeLoans, boolean includeCharges, boolean includeHolds,
+      String sortBy, String limit, String offset, MultiMap headers, Handler<HttpResponse<Buffer>> responseHandler,
       Handler<Throwable> exceptionHandler) {
+    String url = String.format("%s/patron/account/%s?includeLoans=%s&includeCharges=%s&includeHolds=%s",
+      okapiURL,
+      patronId,
+      includeLoans,
+      includeCharges,
+      includeHolds);
+    if (null != sortBy) {
+      url = String.format(url + "&sortBy=%s", sortBy);
+    }
+    if (null != limit) {
+      url = String.format(url + "&limit=%s", limit);
+    }
+    if (null != offset) {
+      url = String.format(url + "&offset=%s", offset);
+    }
+
     get(
-        String.format("%s/patron/account/%s?includeLoans=%s&includeCharges=%s&includeHolds=%s",
-            okapiURL,
-            patronId,
-            includeLoans,
-            includeCharges,
-            includeHolds),
+        url,
         tenant,
         combineHeadersWithDefaults(headers),
         responseHandler,

--- a/src/test/java/org/folio/edge/patron/MainVerticleTest.java
+++ b/src/test/java/org/folio/edge/patron/MainVerticleTest.java
@@ -1341,7 +1341,7 @@ public class MainVerticleTest {
 
     for (int i = 0; i < iters; i++) {
       final Response resp = RestAssured
-        .get(String.format("/patron/account/%s?apikey=%s&limit=10&offset=0", extPatronId, apiKey))
+        .get(String.format("/patron/account/%s?apikey=%s", extPatronId, apiKey))
         .then()
         .contentType(APPLICATION_JSON)
         .statusCode(200)

--- a/src/test/java/org/folio/edge/patron/MainVerticleTest.java
+++ b/src/test/java/org/folio/edge/patron/MainVerticleTest.java
@@ -332,11 +332,11 @@ public class MainVerticleTest {
   }
 
   @Test
-  public void testGetAccountPatronFoundIncludeLoansAndSortBy(TestContext context) throws Exception {
-    logger.info("=== Test getAccount/includeLoans & sortBy ===");
+  public void testGetAccountPatronFoundIncludeLoansAndSortByAndNegativeLimit(TestContext context) throws Exception {
+    logger.info("=== Test getAccount/includeLoans & sortBy & negative limit ===");
 
     final Response resp = RestAssured
-      .get(String.format("/patron/account/%s?apikey=%s&includeLoans=true&includeHolds=false&includeCharges=false&sortBy=testSort&limit=10&offset=0",
+      .get(String.format("/patron/account/%s?apikey=%s&includeLoans=true&includeHolds=false&includeCharges=false&sortBy=testSort&limit=-1",
         patronId, apiKey))
       .then()
       .statusCode(200)
@@ -364,7 +364,44 @@ public class MainVerticleTest {
       .response();
 
     ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
-    assertEquals(wrongOffsetMessage, msg.message);
+    assertEquals(String.format(wrongOffsetMessage, -1), msg.message);
+    assertEquals(expectedStatusCode, msg.httpStatusCode);
+  }
+
+  @Test
+  public void testGetAccountOffsetIsNotNumber(TestContext context) throws Exception {
+    logger.info("=== Test getAccount offset is not a number ===");
+
+    int expectedStatusCode = 400;
+    final Response resp = RestAssured
+      .get(String.format("/patron/account/%s?apikey=%s&includeLoans=true&includeHolds=true&includeCharges=true&limit=1&offset=test",
+        patronId, apiKey))
+      .then()
+      .statusCode(expectedStatusCode)
+      .extract()
+      .response();
+
+    ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
+    assertEquals(String.format(wrongOffsetMessage, "test"), msg.message);
+    assertEquals(expectedStatusCode, msg.httpStatusCode);
+  }
+
+  @Test
+  public void testGetAccountLimitIsNotNumber(TestContext context) throws Exception {
+    logger.info("=== Test getAccount limit is not a number ===");
+
+    int expectedStatusCode = 400;
+    final Response resp = RestAssured
+      .get(String.format("/patron/account/%s?apikey=%s&includeLoans=true&includeHolds=true&includeCharges=true&limit=test",
+        patronId, apiKey))
+      .then()
+      .statusCode(expectedStatusCode)
+      .extract()
+      .response();
+
+    ErrorMessage msg = ErrorMessage.fromJson(resp.body().asString());
+    assertEquals(String.format("'limit' parameter is incorrect. parameter value {%s} is not valid: must be an integer",
+                        "test"), msg.message);
     assertEquals(expectedStatusCode, msg.httpStatusCode);
   }
 

--- a/src/test/java/org/folio/edge/patron/utils/PatronMockOkapi.java
+++ b/src/test/java/org/folio/edge/patron/utils/PatronMockOkapi.java
@@ -193,17 +193,17 @@ public class PatronMockOkapi extends MockOkapi {
         .setStatusCode(404)
         .putHeader(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN)
         .end(patronId + " not found");
-    } else if("-1".equals(offset)) {
+    } else if ("-1".equals(offset)) {
       ctx.response()
         .setStatusCode(400)
         .putHeader(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN)
         .end(wrongOffsetMessage);
-    } else if("1".equals(limit)) {
+    } else if ("1".equals(limit)) {
       ctx.response()
         .setStatusCode(200)
         .putHeader(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON)
         .end(getAccountWithSingleItemsJson(patronId, includeLoans, includeCharges, includeHolds));
-    } else if(StringUtils.isNotEmpty(sortBy)) {
+    } else if (StringUtils.isNotEmpty(sortBy)) {
       ctx.response()
         .setStatusCode(200)
         .putHeader(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON)

--- a/src/test/java/org/folio/edge/patron/utils/PatronMockOkapi.java
+++ b/src/test/java/org/folio/edge/patron/utils/PatronMockOkapi.java
@@ -80,7 +80,7 @@ public class PatronMockOkapi extends MockOkapi {
   public static final String goodRequestId = holdCancellationHoldId ;
   public static final String nonUUIDHoldCanceledByPatronId = "patron@folio.org";
   public static final String patronComments = "Can you deliver this to the History building for Professor Grant?";
-  public static final String wrongOffsetMessage = " 'offset' parameter is incorrect. parameter value {-1} is not valid: must be greater than or equal to 0";
+  public static final String wrongOffsetMessage = "'offset' parameter is incorrect. parameter value {%s} is not valid: must be an integer, greater than or equal to 0";
 
   public static final long checkedOutTs = System.currentTimeMillis() - (34 * DAY_IN_MILLIS);
   public static final long dueDateTs = checkedOutTs + (20 * DAY_IN_MILLIS);

--- a/src/test/java/org/folio/edge/patron/utils/PatronMockOkapi.java
+++ b/src/test/java/org/folio/edge/patron/utils/PatronMockOkapi.java
@@ -1,5 +1,6 @@
 package org.folio.edge.patron.utils;
 
+import static java.util.Collections.singletonList;
 import static org.folio.edge.core.Constants.APPLICATION_JSON;
 import static org.folio.edge.core.Constants.DAY_IN_MILLIS;
 import static org.folio.edge.core.Constants.TEXT_PLAIN;
@@ -10,8 +11,11 @@ import static org.folio.edge.patron.Constants.PARAM_INCLUDE_HOLDS;
 import static org.folio.edge.patron.Constants.PARAM_INCLUDE_LOANS;
 import static org.folio.edge.patron.Constants.PARAM_INSTANCE_ID;
 import static org.folio.edge.patron.Constants.PARAM_ITEM_ID;
+import static org.folio.edge.patron.Constants.PARAM_LIMIT;
+import static org.folio.edge.patron.Constants.PARAM_OFFSET;
 import static org.folio.edge.patron.Constants.PARAM_PATRON_ID;
 import static org.folio.edge.patron.Constants.PARAM_REQUEST_ID;
+import static org.folio.edge.patron.Constants.PARAM_SORT_BY;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -24,6 +28,7 @@ import java.util.List;
 import java.util.UUID;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.edge.core.utils.test.MockOkapi;
@@ -75,6 +80,7 @@ public class PatronMockOkapi extends MockOkapi {
   public static final String goodRequestId = holdCancellationHoldId ;
   public static final String nonUUIDHoldCanceledByPatronId = "patron@folio.org";
   public static final String patronComments = "Can you deliver this to the History building for Professor Grant?";
+  public static final String wrongOffsetMessage = " 'offset' parameter is incorrect. parameter value {-1} is not valid: must be greater than or equal to 0";
 
   public static final long checkedOutTs = System.currentTimeMillis() - (34 * DAY_IN_MILLIS);
   public static final long dueDateTs = checkedOutTs + (20 * DAY_IN_MILLIS);
@@ -171,6 +177,9 @@ public class PatronMockOkapi extends MockOkapi {
     boolean includeLoans = Boolean.parseBoolean(ctx.request().getParam(PARAM_INCLUDE_LOANS));
     boolean includeCharges = Boolean.parseBoolean(ctx.request().getParam(PARAM_INCLUDE_CHARGES));
     boolean includeHolds = Boolean.parseBoolean(ctx.request().getParam(PARAM_INCLUDE_HOLDS));
+    String limit  = ctx.request().getParam(PARAM_LIMIT);
+    String offset  = ctx.request().getParam(PARAM_OFFSET);
+    String sortBy = ctx.request().getParam(PARAM_SORT_BY);
 
     if (token == null || !token.equals(MOCK_TOKEN)) {
       ctx.response()
@@ -184,6 +193,21 @@ public class PatronMockOkapi extends MockOkapi {
         .setStatusCode(404)
         .putHeader(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN)
         .end(patronId + " not found");
+    } else if("-1".equals(offset)) {
+      ctx.response()
+        .setStatusCode(400)
+        .putHeader(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN)
+        .end(wrongOffsetMessage);
+    } else if("1".equals(limit)) {
+      ctx.response()
+        .setStatusCode(200)
+        .putHeader(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON)
+        .end(getAccountWithSingleItemsJson(patronId, includeLoans, includeCharges, includeHolds));
+    } else if(StringUtils.isNotEmpty(sortBy)) {
+      ctx.response()
+        .setStatusCode(200)
+        .putHeader(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON)
+        .end(getAccountWithSortedLoans(patronId));
     } else {
       ctx.response()
         .setStatusCode(200)
@@ -440,16 +464,48 @@ public class PatronMockOkapi extends MockOkapi {
 
     List<Charge> charges = new ArrayList<>();
     charges.add(getCharge(itemId_overdue));
+    charges.add(getCharge(itemId));
     acctBldr.charges(charges);
 
     List<Hold> holds = new ArrayList<>();
+    holds.add(getHold(itemId_overdue));
     holds.add(getHold(itemId));
     acctBldr.holds(holds);
 
     List<Loan> loans = new ArrayList<>();
     loans.add(getLoan(itemId_overdue));
+    loans.add(getLoan(itemId));
     acctBldr.loans(loans);
 
+    return builderToJson(acctBldr, includeLoans, includeCharges, includeHolds);
+  }
+
+  public static String getAccountWithSingleItemsJson(String patronId, boolean includeLoans, boolean includeCharges,
+    boolean includeHolds) {
+
+    Account.Builder acctBldr = Account.builder()
+      .id(patronId);
+    acctBldr.loans(singletonList(getLoan(itemId)));
+    acctBldr.holds(singletonList(getHold(itemId)));
+    acctBldr.charges(singletonList(getCharge(itemId)));
+
+    return builderToJson(acctBldr, includeLoans, includeCharges, includeHolds);
+  }
+
+  public static String getAccountWithSortedLoans(String patronId) {
+
+    Account.Builder acctBldr = Account.builder()
+      .id(patronId);
+    List<Loan> loans = new ArrayList<>();
+    loans.add(getLoan(itemId));
+    loans.add(getLoan(itemId_overdue));
+    acctBldr.loans(loans);
+
+    return builderToJson(acctBldr, true, false, false);
+  }
+
+  private static String builderToJson(Account.Builder acctBldr, boolean includeLoans, boolean includeCharges,
+    boolean includeHolds) {
     String ret = null;
     try {
       ret = acctBldr.build().toJson(includeLoans, includeCharges, includeHolds);
@@ -461,6 +517,7 @@ public class PatronMockOkapi extends MockOkapi {
 
   public static Item getItem(String itemId) {
     return Item.builder()
+      .itemId(itemId)
       .title("The Stars My Destination")
       .author("Bester, Alfred")
       .instanceId(instanceId)

--- a/src/test/java/org/folio/edge/patron/utils/PatronOkapiClientCompressionTest.java
+++ b/src/test/java/org/folio/edge/patron/utils/PatronOkapiClientCompressionTest.java
@@ -1,15 +1,5 @@
 package org.folio.edge.patron.utils;
 
-import java.util.UUID;
-
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.folio.edge.core.utils.test.TestUtils;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-
 import io.vertx.core.MultiMap;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpServer;
@@ -17,6 +7,14 @@ import io.vertx.core.http.HttpServerOptions;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import java.util.UUID;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.folio.edge.core.utils.test.TestUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
 
 @RunWith(VertxUnitRunner.class)
 public class PatronOkapiClientCompressionTest {
@@ -67,17 +65,18 @@ public class PatronOkapiClientCompressionTest {
     headers.add("Accept-Encoding", "gzip");
     Async async = context.async();
     client.getAccount(patronId,
-        true,
-        true,
-        true,
+      true,
+      true,
+      true,
+      null,
+      null,
+      null,
         headers,
         resp -> {
           logger.info("mod-patron response body: " + resp.body());
           context.assertEquals("{\"test\":\"1234\"}", resp.bodyAsString());
           async.complete();
         },
-        t -> {
-          context.fail(t);
-        });
+        context::fail);
   }
 }

--- a/src/test/java/org/folio/edge/patron/utils/PatronOkapiClientCompressionTest.java
+++ b/src/test/java/org/folio/edge/patron/utils/PatronOkapiClientCompressionTest.java
@@ -65,12 +65,12 @@ public class PatronOkapiClientCompressionTest {
     headers.add("Accept-Encoding", "gzip");
     Async async = context.async();
     client.getAccount(patronId,
-      true,
-      true,
-      true,
-      null,
-      null,
-      null,
+        true,
+        true,
+        true,
+        null,
+        null,
+        null,
         headers,
         resp -> {
           logger.info("mod-patron response body: " + resp.body());

--- a/src/test/java/org/folio/edge/patron/utils/PatronOkapiClientTest.java
+++ b/src/test/java/org/folio/edge/patron/utils/PatronOkapiClientTest.java
@@ -114,8 +114,8 @@ public class PatronOkapiClientTest {
           true,
           true,
           null,
-        null,
-        null,
+          null,
+          null,
           resp -> {
             logger.info("mod-patron response body: " + resp.body());
             String accountResponse = resp.bodyAsString();
@@ -232,9 +232,9 @@ public class PatronOkapiClientTest {
           true,
           true,
           true,
-              null,
-        null,
-        null,
+          null,
+          null,
+          null,
           resp -> {
             logger.info("mod-patron response body: " + resp.body());
             context.assertEquals(404, resp.statusCode());
@@ -256,9 +256,9 @@ public class PatronOkapiClientTest {
           true,
           true,
           false,
-        null,
-        null,
-        null,
+          null,
+          null,
+          null,
           resp -> {
             logger.info("mod-patron response body: " + resp.body());
             context.assertEquals(PatronMockOkapi.getAccountJson(patronId, true, true, false), resp.bodyAsString());
@@ -281,8 +281,8 @@ public class PatronOkapiClientTest {
           false,
           true,
           null,
-        null,
-        null,
+          null,
+          null,
           resp -> {
             logger.info("mod-patron response body: " + resp.body());
             context.assertEquals(PatronMockOkapi.getAccountJson(patronId, true, false, true), resp.bodyAsString());
@@ -304,9 +304,9 @@ public class PatronOkapiClientTest {
           false,
           true,
           true,
-        null,
-        null,
-        null,
+          null,
+          null,
+          null,
           resp -> {
             logger.info("mod-patron response body: " + resp.body());
             context.assertEquals(PatronMockOkapi.getAccountJson(patronId, false, true, true), resp.bodyAsString());
@@ -328,9 +328,9 @@ public class PatronOkapiClientTest {
           false,
           false,
           false,
-        null,
-        null,
-        null,
+          null,
+          null,
+          null,
           resp -> {
             logger.info("mod-patron response body: " + resp.body());
             context.assertEquals(PatronMockOkapi.getAccountJson(patronId, false, false, false), resp.bodyAsString());
@@ -349,9 +349,9 @@ public class PatronOkapiClientTest {
         false,
         false,
         false,
-      null,
-      null,
-      null,
+        null,
+        null,
+        null,
         resp -> {
           logger.info("mod-patron response body: " + resp.body());
           context.assertEquals(403, resp.statusCode());

--- a/src/test/java/org/folio/edge/patron/utils/PatronOkapiClientTest.java
+++ b/src/test/java/org/folio/edge/patron/utils/PatronOkapiClientTest.java
@@ -1,6 +1,7 @@
 package org.folio.edge.patron.utils;
 
 import static org.folio.edge.core.utils.test.MockOkapi.MOCK_TOKEN;
+import static org.folio.edge.patron.utils.PatronMockOkapi.wrongOffsetMessage;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
@@ -13,6 +14,7 @@ import io.vertx.core.json.JsonObject;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.edge.core.utils.test.TestUtils;
+import org.folio.edge.patron.model.Account;
 import org.folio.edge.patron.model.Hold;
 import org.folio.edge.patron.utils.PatronOkapiClient.PatronLookupException;
 import org.junit.After;
@@ -111,14 +113,110 @@ public class PatronOkapiClientTest {
           true,
           true,
           true,
+          null,
+        null,
+        null,
           resp -> {
             logger.info("mod-patron response body: " + resp.body());
-            context.assertEquals(PatronMockOkapi.getAccountJson(patronId, true, true, true), resp.bodyAsString());
+            String accountResponse = resp.bodyAsString();
+            context.assertEquals(PatronMockOkapi.getAccountJson(patronId, true, true, true), accountResponse);
+            try {
+              verifyAccountItemsSize(accountResponse, 2);
+            } catch (IOException e) {
+              logger.error(e.getMessage());
+              context.fail(e);
+            }
             async.complete();
           },
-          t -> {
-            context.fail(t);
-          });
+        context::fail);
+    });
+  }
+
+  @Test
+  public void testGetAccountWithSortedLoans(TestContext context) throws Exception {
+    logger.info("=== Test successful getAccount request w/ sorted loans data ===");
+
+    Async async = context.async();
+    client.login("admin", "password").thenAcceptAsync(v -> {
+      assertEquals(MOCK_TOKEN, client.getToken());
+
+      client.getAccount(patronId,
+        true,
+        true,
+        true,
+        "testSort",
+        null,
+        null,
+        resp -> {
+          logger.info("mod-patron response body: " + resp.body());
+          try {
+            String accountResponse = resp.bodyAsString();
+            Account account = Account.fromJson(accountResponse);
+            context.assertEquals(PatronMockOkapi.getAccountWithSortedLoans(patronId), accountResponse);
+            context.assertEquals(PatronMockOkapi.itemId, account.loans.get(0).item.itemId);
+            context.assertEquals(PatronMockOkapi.itemId_overdue, account.loans.get(1).item.itemId);
+            async.complete();
+          } catch (IOException e) {
+            context.fail(e);
+          }
+        },
+        context::fail);
+    });
+  }
+
+  @Test
+  public void testGetAccountWithAllAndLimitEqualsToOne(TestContext context) throws Exception {
+    logger.info("=== Test successful getAccount request w/ all data and limit=1 ===");
+
+    Async async = context.async();
+    client.login("admin", "password").thenAcceptAsync(v -> {
+      assertEquals(MOCK_TOKEN, client.getToken());
+
+      client.getAccount(patronId,
+        true,
+        true,
+        true,
+        null,
+        "1",
+        null,
+        resp -> {
+          logger.info("mod-patron response body: " + resp.body());
+          String accountResponse = resp.bodyAsString();
+          context.assertEquals(PatronMockOkapi.getAccountWithSingleItemsJson(patronId, true, true, true), accountResponse);
+          try {
+            verifyAccountItemsSize(accountResponse, 1);
+          } catch (IOException e) {
+            logger.error(e.getMessage());
+            context.fail(e);
+          }
+          async.complete();
+        },
+        context::fail);
+    });
+  }
+
+  @Test
+  public void testGetAccountOffsetIsWrong(TestContext context) throws Exception {
+    logger.info("=== Test getAccount - offset is wrong ===");
+
+    Async async = context.async();
+    client.login("admin", "password").thenAcceptAsync(v -> {
+      assertEquals(MOCK_TOKEN, client.getToken());
+
+      client.getAccount(PatronMockOkapi.patronId,
+        true,
+        true,
+        true,
+        null,
+        null,
+        "-1",
+        resp -> {
+          logger.info("mod-patron response body: " + resp.body());
+          context.assertEquals(400, resp.statusCode());
+          context.assertEquals(wrongOffsetMessage, resp.bodyAsString());
+          async.complete();
+        },
+        context::fail);
     });
   }
 
@@ -134,14 +232,15 @@ public class PatronOkapiClientTest {
           true,
           true,
           true,
+              null,
+        null,
+        null,
           resp -> {
             logger.info("mod-patron response body: " + resp.body());
             context.assertEquals(404, resp.statusCode());
             async.complete();
           },
-          t -> {
-            context.fail(t);
-          });
+        context::fail);
     });
   }
 
@@ -157,14 +256,15 @@ public class PatronOkapiClientTest {
           true,
           true,
           false,
+        null,
+        null,
+        null,
           resp -> {
             logger.info("mod-patron response body: " + resp.body());
             context.assertEquals(PatronMockOkapi.getAccountJson(patronId, true, true, false), resp.bodyAsString());
             async.complete();
           },
-          t -> {
-            context.fail(t);
-          });
+        context::fail);
     });
   }
 
@@ -180,14 +280,15 @@ public class PatronOkapiClientTest {
           true,
           false,
           true,
+          null,
+        null,
+        null,
           resp -> {
             logger.info("mod-patron response body: " + resp.body());
             context.assertEquals(PatronMockOkapi.getAccountJson(patronId, true, false, true), resp.bodyAsString());
             async.complete();
           },
-          t -> {
-            context.fail(t);
-          });
+        context::fail);
     });
   }
 
@@ -203,14 +304,15 @@ public class PatronOkapiClientTest {
           false,
           true,
           true,
+        null,
+        null,
+        null,
           resp -> {
             logger.info("mod-patron response body: " + resp.body());
             context.assertEquals(PatronMockOkapi.getAccountJson(patronId, false, true, true), resp.bodyAsString());
             async.complete();
           },
-          t -> {
-            context.fail(t);
-          });
+        context::fail);
     });
   }
 
@@ -226,14 +328,15 @@ public class PatronOkapiClientTest {
           false,
           false,
           false,
+        null,
+        null,
+        null,
           resp -> {
             logger.info("mod-patron response body: " + resp.body());
             context.assertEquals(PatronMockOkapi.getAccountJson(patronId, false, false, false), resp.bodyAsString());
             async.complete();
           },
-          t -> {
-            context.fail(t);
-          });
+        context::fail);
     });
   }
 
@@ -246,14 +349,15 @@ public class PatronOkapiClientTest {
         false,
         false,
         false,
+      null,
+      null,
+      null,
         resp -> {
           logger.info("mod-patron response body: " + resp.body());
           context.assertEquals(403, resp.statusCode());
           async.complete();
         },
-        t -> {
-          context.fail(t);
-        });
+        context::fail);
   }
 
   @Test
@@ -270,9 +374,7 @@ public class PatronOkapiClientTest {
             context.assertEquals(201, resp.statusCode());
             async.complete();
           },
-          t -> {
-            context.fail(t);
-          });
+          context::fail);
     });
   }
 
@@ -290,9 +392,7 @@ public class PatronOkapiClientTest {
             context.assertEquals(404, resp.statusCode());
             async.complete();
           },
-          t -> {
-            context.fail(t);
-          });
+         context::fail);
     });
   }
 
@@ -310,9 +410,7 @@ public class PatronOkapiClientTest {
             context.assertEquals(404, resp.statusCode());
             async.complete();
           },
-          t -> {
-            context.fail(t);
-          });
+          context::fail);
     });
   }
 
@@ -334,9 +432,7 @@ public class PatronOkapiClientTest {
             context.assertEquals(201, resp.statusCode());
             async.complete();
           },
-          t -> {
-            context.fail(t);
-          });
+          context::fail);
     });
   }
 
@@ -358,9 +454,7 @@ public class PatronOkapiClientTest {
             context.assertEquals(404, resp.statusCode());
             async.complete();
           },
-          t -> {
-            context.fail(t);
-          });
+          context::fail);
     });
   }
 
@@ -382,9 +476,7 @@ public class PatronOkapiClientTest {
             context.assertEquals(404, resp.statusCode());
             async.complete();
           },
-          t -> {
-            context.fail(t);
-          });
+          context::fail);
     });
   }
 
@@ -411,9 +503,7 @@ public class PatronOkapiClientTest {
             }
             async.complete();
           },
-          t -> {
-            context.fail(t);
-          });
+          context::fail);
     });
   }
 
@@ -434,9 +524,7 @@ public class PatronOkapiClientTest {
             context.assertEquals(404, resp.statusCode());
             async.complete();
           },
-          t -> {
-            context.fail(t);
-          });
+          context::fail);
     });
   }
 
@@ -455,9 +543,7 @@ public class PatronOkapiClientTest {
             context.assertEquals(404, resp.statusCode());
             async.complete();
           },
-          t -> {
-            context.fail(t);
-          });
+          context::fail);
     });
   }
 
@@ -475,9 +561,7 @@ public class PatronOkapiClientTest {
           context.assertEquals(PatronMockOkapi.getRequest(PatronMockOkapi.holdCancellationHoldId), resp.bodyAsString());
           async.complete();
         },
-        t -> {
-          context.fail(t);
-        });
+        context::fail);
     });
   }
 
@@ -498,9 +582,14 @@ public class PatronOkapiClientTest {
           context.assertEquals(expectedResponse, resp.bodyAsString());
           async.complete();
         },
-        t -> {
-          context.fail(t);
-        });
+        context::fail);
     });
+  }
+
+  private void verifyAccountItemsSize(String accountString, int itemsSize) throws IOException {
+      Account account = Account.fromJson(accountString);
+      assertEquals(itemsSize, account.charges.size());
+      assertEquals(itemsSize, account.holds.size());
+      assertEquals(itemsSize, account.loans.size());
   }
 }


### PR DESCRIPTION
Purpose:
https://issues.folio.org/browse/EDGPATRON-62

Approach:
Added support of new query params in **/patron/account/{id} API**, such as limit. offset, sortBy.