### PR TITLE
EDGPATRON-67: Update Log4j to 2.16.0 (Kiwi R3 2021).

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## 4.6.1 IN-PROGRESS
+
+* Update Log4j to 2.16.0. (CVE-2021-44228) (EDGPATRON-67)
+
 ## 4.6.0 2021-09-27
 
 * Upgrade to vert.x 4.x [EDGPATRON-39] (https://issues.folio.org/browse/EDGPATRON-39)

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-bom</artifactId>
-        <version>2.13.3</version>
+        <version>2.16.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Resolve CVE-2021-44228 as per [EDGPATRON-67](https://issues.folio.org/browse/EDGPATRON-67).