### PR TITLE
EDGPATRON-67: Update Log4j to 2.16.0 (Lotus).

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 * Removed UUID string pattern from RAML file, as module now uses externalSystemID to look up patron data [EDGPATRON-61] (https://issues.folio.org/browse/EDGPATRON-61)
 * Include API key parameter for every endpoint in RAML. [EDGPATRON-63](https://issues.folio.org/browse/EDGPATRON-63)
+* Update Log4j to 2.16.0. (CVE-2021-44228) [EDGPATRON-67](https://issues.folio.org/browse/EDGPATRON-67)
 
 ## 4.6.0 2021-09-27
 

--- a/pom.xml
+++ b/pom.xml
@@ -55,7 +55,7 @@
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-bom</artifactId>
-        <version>2.13.3</version>
+        <version>2.16.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Resolve CVE-2021-44228 as per [EDGPATRON-67](https://issues.folio.org/browse/EDGPATRON-67).