### PR TITLE
EDGPATRON-69: Update to Log4J 2.16.0 (Juniper R2 2021).

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## 4.5.1 IN-PROGRESS
+
+* Update Log4J to 2.16.0. (CVE-2021-4104) (EDGPATRON-69)
+
 ## 4.5.0 2021-06-17
 
 * Requires `circulation 9.5 10.0 or 11.0` ([EDGPATRON-44](https://issues.folio.org/browse/EDGPATRON-44), [EDGPATRON-46](https://issues.folio.org/browse/EDGPATRON-46))

--- a/pom.xml
+++ b/pom.xml
@@ -38,6 +38,13 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-bom</artifactId>
+        <version>2.16.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
         <version>3.5.4</version>
@@ -117,14 +124,16 @@
 
     <!-- we use log4j as our logging implementation -->
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
-      <version>1.7.13</version>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <version>1.2.17</version>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-1.2-api</artifactId>
     </dependency>
 
     <!-- include slf4j bridges to proxy all logging from library deps to

--- a/src/main/java/org/folio/edge/patron/MainVerticle.java
+++ b/src/main/java/org/folio/edge/patron/MainVerticle.java
@@ -7,7 +7,8 @@ import static org.folio.edge.patron.Constants.SYS_NULL_PATRON_ID_CACHE_TTL_MS;
 import static org.folio.edge.patron.Constants.SYS_PATRON_ID_CACHE_CAPACITY;
 import static org.folio.edge.patron.Constants.SYS_PATRON_ID_CACHE_TTL_MS;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.folio.edge.core.EdgeVerticle;
 import org.folio.edge.patron.cache.PatronIdCache;
 import org.folio.edge.patron.utils.PatronOkapiClientFactory;
@@ -18,7 +19,7 @@ import io.vertx.ext.web.handler.BodyHandler;
 
 public class MainVerticle extends EdgeVerticle {
 
-  private static final Logger logger = Logger.getLogger(MainVerticle.class);
+  private static final Logger logger = LogManager.getLogger(MainVerticle.class);
 
   public MainVerticle() {
     super();

--- a/src/main/java/org/folio/edge/patron/PatronHandler.java
+++ b/src/main/java/org/folio/edge/patron/PatronHandler.java
@@ -23,23 +23,25 @@ import java.util.Map;
 import java.util.TimeZone;
 import java.util.concurrent.TimeoutException;
 
-import io.vertx.core.json.JsonObject;
-import org.folio.edge.patron.model.error.Error;
-import org.folio.edge.patron.model.error.Errors;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import io.vertx.core.http.HttpClientResponse;
-import io.vertx.core.http.HttpServerResponse;
-import io.vertx.core.json.Json;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.folio.edge.core.Handler;
 import org.folio.edge.core.security.SecureStore;
 import org.folio.edge.core.utils.OkapiClient;
+import org.folio.edge.patron.model.error.Error;
 import org.folio.edge.patron.model.error.ErrorMessage;
+import org.folio.edge.patron.model.error.Errors;
 import org.folio.edge.patron.utils.PatronIdHelper;
 import org.folio.edge.patron.utils.PatronOkapiClient;
 import org.folio.edge.patron.utils.PatronOkapiClientFactory;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+import io.vertx.core.http.HttpClientResponse;
 import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.RoutingContext;
 
 public class PatronHandler extends Handler {
@@ -47,7 +49,7 @@ public class PatronHandler extends Handler {
   public PatronHandler(SecureStore secureStore, PatronOkapiClientFactory ocf) {
     super(secureStore, ocf);
   }
-  private static final Logger logger = Logger.getLogger(Handler.class);
+  private static final Logger logger = LogManager.getLogger(Handler.class);
   private static final String CONTENT_LENGTH = "content-length";
 
   @Override

--- a/src/main/java/org/folio/edge/patron/cache/PatronIdCache.java
+++ b/src/main/java/org/folio/edge/patron/cache/PatronIdCache.java
@@ -1,13 +1,14 @@
 package org.folio.edge.patron.cache;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.folio.edge.core.cache.Cache;
 import org.folio.edge.core.cache.Cache.Builder;
 import org.folio.edge.core.cache.Cache.CacheValue;
 
 public class PatronIdCache {
 
-  private static final Logger logger = Logger.getLogger(PatronIdCache.class);
+  private static final Logger logger = LogManager.getLogger(PatronIdCache.class);
 
   private static PatronIdCache instance = null;
 

--- a/src/main/java/org/folio/edge/patron/utils/PatronIdHelper.java
+++ b/src/main/java/org/folio/edge/patron/utils/PatronIdHelper.java
@@ -2,7 +2,8 @@ package org.folio.edge.patron.utils;
 
 import java.util.concurrent.CompletableFuture;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.folio.edge.core.cache.TokenCache.NotInitializedException;
 import org.folio.edge.patron.cache.PatronIdCache;
 
@@ -10,7 +11,7 @@ import me.escoffier.vertx.completablefuture.VertxCompletableFuture;
 
 public class PatronIdHelper {
 
-  private static final Logger logger = Logger.getLogger(PatronIdHelper.class);
+  private static final Logger logger = LogManager.getLogger(PatronIdHelper.class);
 
   private PatronIdHelper() {
 

--- a/src/main/java/org/folio/edge/patron/utils/PatronOkapiClient.java
+++ b/src/main/java/org/folio/edge/patron/utils/PatronOkapiClient.java
@@ -1,9 +1,17 @@
 package org.folio.edge.patron.utils;
 
+import static org.folio.edge.patron.Constants.FIELD_CANCELED_DATE;
+import static org.folio.edge.patron.Constants.FIELD_CANCELLATION_ADDITIONAL_INFO;
+import static org.folio.edge.patron.Constants.FIELD_CANCELLATION_REASON_ID;
+
 import java.util.concurrent.CompletableFuture;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.folio.edge.core.utils.OkapiClient;
+import org.folio.edge.patron.model.Hold;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
@@ -11,17 +19,10 @@ import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpClientResponse;
 import io.vertx.core.json.JsonObject;
 import me.escoffier.vertx.completablefuture.VertxCompletableFuture;
-import org.folio.edge.patron.model.Hold;
-import org.joda.time.DateTime;
-import org.joda.time.DateTimeZone;
-
-import static org.folio.edge.patron.Constants.FIELD_CANCELED_DATE;
-import static org.folio.edge.patron.Constants.FIELD_CANCELLATION_ADDITIONAL_INFO;
-import static org.folio.edge.patron.Constants.FIELD_CANCELLATION_REASON_ID;
 
 public class PatronOkapiClient extends OkapiClient {
 
-  private static final Logger logger = Logger.getLogger(PatronOkapiClient.class);
+  private static final Logger logger = LogManager.getLogger(PatronOkapiClient.class);
 
   public PatronOkapiClient(OkapiClient client) {
     super(client);

--- a/src/test/java/org/folio/edge/patron/MainVerticleTest.java
+++ b/src/test/java/org/folio/edge/patron/MainVerticleTest.java
@@ -18,9 +18,9 @@ import static org.folio.edge.patron.utils.PatronMockOkapi.invalidHoldCancellatio
 import static org.folio.edge.patron.utils.PatronMockOkapi.malformedHoldCancellationHoldId;
 import static org.folio.edge.patron.utils.PatronMockOkapi.nonUUIDHoldCanceledByPatronId;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.junit.Assert.assertNull;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.spy;
@@ -37,13 +37,14 @@ import java.util.UUID;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpHeaders;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.folio.edge.core.utils.ApiKeyUtils;
 import org.folio.edge.core.utils.test.TestUtils;
 import org.folio.edge.patron.model.Account;
-import org.folio.edge.patron.model.error.ErrorMessage;
 import org.folio.edge.patron.model.Hold;
 import org.folio.edge.patron.model.Loan;
+import org.folio.edge.patron.model.error.ErrorMessage;
 import org.folio.edge.patron.utils.PatronMockOkapi;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -53,7 +54,6 @@ import org.junit.runner.RunWith;
 
 import io.restassured.RestAssured;
 import io.restassured.response.Response;
-
 import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Vertx;
 import io.vertx.ext.unit.Async;
@@ -63,7 +63,7 @@ import io.vertx.ext.unit.junit.VertxUnitRunner;
 @RunWith(VertxUnitRunner.class)
 public class MainVerticleTest {
 
-  private static final Logger logger = Logger.getLogger(MainVerticleTest.class);
+  private static final Logger logger = LogManager.getLogger(MainVerticleTest.class);
 
   private static final String extPatronId = PatronMockOkapi.extPatronId;
   private static final String patronId = PatronMockOkapi.patronId;

--- a/src/test/java/org/folio/edge/patron/cache/PatronIdCacheTest.java
+++ b/src/test/java/org/folio/edge/patron/cache/PatronIdCacheTest.java
@@ -7,14 +7,15 @@ import static org.junit.Assert.assertNull;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.folio.edge.core.cache.Cache.CacheValue;
 import org.junit.Before;
 import org.junit.Test;
 
 public class PatronIdCacheTest {
 
-  private static final Logger logger = Logger.getLogger(PatronIdCacheTest.class);
+  private static final Logger logger = LogManager.getLogger(PatronIdCacheTest.class);
 
   private static final int cap = 50;
   private static final long ttl = 3000;

--- a/src/test/java/org/folio/edge/patron/model/AccountTest.java
+++ b/src/test/java/org/folio/edge/patron/model/AccountTest.java
@@ -22,7 +22,8 @@ import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
 import javax.xml.validation.Validator;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.everit.json.schema.loader.SchemaLoader;
 import org.folio.edge.patron.model.Hold.Status;
 import org.json.JSONObject;
@@ -35,7 +36,7 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 
 public class AccountTest {
 
-  private static final Logger logger = Logger.getLogger(AccountTest.class);
+  private static final Logger logger = LogManager.getLogger(AccountTest.class);
   private static final String SCHEMA = "ramls/account.json";
   private static final String XSD = "ramls/patron.xsd";
 

--- a/src/test/java/org/folio/edge/patron/model/ChargeTest.java
+++ b/src/test/java/org/folio/edge/patron/model/ChargeTest.java
@@ -21,7 +21,8 @@ import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
 import javax.xml.validation.Validator;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.everit.json.schema.FormatValidator;
 import org.everit.json.schema.loader.SchemaLoader;
 import org.folio.edge.core.utils.Mappers;
@@ -35,7 +36,7 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 
 public class ChargeTest {
 
-  private static final Logger logger = Logger.getLogger(ChargeTest.class);
+  private static final Logger logger = LogManager.getLogger(ChargeTest.class);
   private static final String SCHEMA = "ramls/charge.json";
   private static final String XSD = "ramls/patron.xsd";
 

--- a/src/test/java/org/folio/edge/patron/model/HoldCancellationTest.java
+++ b/src/test/java/org/folio/edge/patron/model/HoldCancellationTest.java
@@ -1,22 +1,8 @@
 package org.folio.edge.patron.model;
 
-import nl.jqno.equalsverifier.EqualsVerifier;
-import org.apache.log4j.Logger;
-import org.everit.json.schema.FormatValidator;
-import org.everit.json.schema.loader.SchemaLoader;
-import org.folio.edge.core.utils.Mappers;
-import org.json.JSONObject;
-import org.json.JSONTokener;
-import org.junit.Before;
-import org.junit.Test;
-import org.xml.sax.SAXException;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 
-import javax.xml.XMLConstants;
-import javax.xml.transform.Source;
-import javax.xml.transform.stream.StreamSource;
-import javax.xml.validation.Schema;
-import javax.xml.validation.SchemaFactory;
-import javax.xml.validation.Validator;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -26,12 +12,29 @@ import java.util.Date;
 import java.util.Optional;
 import java.util.UUID;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import javax.xml.XMLConstants;
+import javax.xml.transform.Source;
+import javax.xml.transform.stream.StreamSource;
+import javax.xml.validation.Schema;
+import javax.xml.validation.SchemaFactory;
+import javax.xml.validation.Validator;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.everit.json.schema.FormatValidator;
+import org.everit.json.schema.loader.SchemaLoader;
+import org.folio.edge.core.utils.Mappers;
+import org.json.JSONObject;
+import org.json.JSONTokener;
+import org.junit.Before;
+import org.junit.Test;
+import org.xml.sax.SAXException;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
 
 public class HoldCancellationTest {
 
-  private static final Logger logger = Logger.getLogger(HoldCancellationTest.class);
+  private static final Logger logger = LogManager.getLogger(HoldCancellationTest.class);
   private static final String SCHEMA = "ramls/hold-cancellation.json";
   private static final String XSD = "ramls/patron.xsd";
 

--- a/src/test/java/org/folio/edge/patron/model/HoldTest.java
+++ b/src/test/java/org/folio/edge/patron/model/HoldTest.java
@@ -20,7 +20,8 @@ import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
 import javax.xml.validation.Validator;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.everit.json.schema.FormatValidator;
 import org.everit.json.schema.loader.SchemaLoader;
 import org.folio.edge.core.utils.Mappers;
@@ -35,7 +36,7 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 
 public class HoldTest {
 
-  private static final Logger logger = Logger.getLogger(HoldTest.class);
+  private static final Logger logger = LogManager.getLogger(HoldTest.class);
   private static final String SCHEMA = "ramls/hold.json";
   private static final String XSD = "ramls/patron.xsd";
 

--- a/src/test/java/org/folio/edge/patron/model/ItemTest.java
+++ b/src/test/java/org/folio/edge/patron/model/ItemTest.java
@@ -16,7 +16,8 @@ import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
 import javax.xml.validation.Validator;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.everit.json.schema.loader.SchemaLoader;
 import org.json.JSONObject;
 import org.json.JSONTokener;
@@ -28,7 +29,7 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 
 public class ItemTest {
 
-  private static final Logger logger = Logger.getLogger(ItemTest.class);
+  private static final Logger logger = LogManager.getLogger(ItemTest.class);
   private static final String SCHEMA = "ramls/item.json";
   private static final String XSD = "ramls/patron.xsd";
 

--- a/src/test/java/org/folio/edge/patron/model/MoneyTest.java
+++ b/src/test/java/org/folio/edge/patron/model/MoneyTest.java
@@ -16,7 +16,8 @@ import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
 import javax.xml.validation.Validator;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.everit.json.schema.loader.SchemaLoader;
 import org.json.JSONObject;
 import org.json.JSONTokener;
@@ -28,7 +29,7 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 
 public class MoneyTest {
 
-  private static final Logger logger = Logger.getLogger(MoneyTest.class);
+  private static final Logger logger = LogManager.getLogger(MoneyTest.class);
   private static final String SCHEMA = "ramls/money.json";
   private static final String XSD = "ramls/patron.xsd";
 

--- a/src/test/java/org/folio/edge/patron/model/loanTest.java
+++ b/src/test/java/org/folio/edge/patron/model/loanTest.java
@@ -20,7 +20,8 @@ import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
 import javax.xml.validation.Validator;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.everit.json.schema.FormatValidator;
 import org.everit.json.schema.loader.SchemaLoader;
 import org.folio.edge.core.utils.Mappers;
@@ -34,7 +35,7 @@ import nl.jqno.equalsverifier.EqualsVerifier;
 
 public class loanTest {
 
-  private static final Logger logger = Logger.getLogger(loanTest.class);
+  private static final Logger logger = LogManager.getLogger(loanTest.class);
   private static final String SCHEMA = "ramls/loan.json";
   private static final String XSD = "ramls/patron.xsd";
 

--- a/src/test/java/org/folio/edge/patron/utils/PatronMockOkapi.java
+++ b/src/test/java/org/folio/edge/patron/utils/PatronMockOkapi.java
@@ -24,7 +24,8 @@ import java.util.List;
 import java.util.UUID;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.folio.edge.core.utils.test.MockOkapi;
 import org.folio.edge.patron.model.Account;
 import org.folio.edge.patron.model.Charge;
@@ -46,7 +47,7 @@ import org.folio.edge.patron.model.Money;
 
 public class PatronMockOkapi extends MockOkapi {
 
-  private static final Logger logger = Logger.getLogger(PatronMockOkapi.class);
+  private static final Logger logger = LogManager.getLogger(PatronMockOkapi.class);
 
   public static final String PARAM_QUERY = "query";
 

--- a/src/test/java/org/folio/edge/patron/utils/PatronOkapiClientCompressionTest.java
+++ b/src/test/java/org/folio/edge/patron/utils/PatronOkapiClientCompressionTest.java
@@ -2,7 +2,8 @@ package org.folio.edge.patron.utils;
 
 import java.util.UUID;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.folio.edge.core.utils.test.TestUtils;
 import org.junit.After;
 import org.junit.Before;
@@ -19,7 +20,7 @@ import io.vertx.ext.unit.junit.VertxUnitRunner;
 
 @RunWith(VertxUnitRunner.class)
 public class PatronOkapiClientCompressionTest {
-  private static final Logger logger = Logger.getLogger(PatronOkapiClientCompressionTest.class);
+  private static final Logger logger = LogManager.getLogger(PatronOkapiClientCompressionTest.class);
 
   private final Vertx vertx = Vertx.vertx();
 

--- a/src/test/java/org/folio/edge/patron/utils/PatronOkapiClientTest.java
+++ b/src/test/java/org/folio/edge/patron/utils/PatronOkapiClientTest.java
@@ -9,8 +9,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
-import io.vertx.core.json.JsonObject;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.folio.edge.core.utils.test.TestUtils;
 import org.folio.edge.patron.model.Hold;
 import org.folio.edge.patron.utils.PatronOkapiClient.PatronLookupException;
@@ -20,6 +20,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
@@ -27,7 +28,7 @@ import io.vertx.ext.unit.junit.VertxUnitRunner;
 @RunWith(VertxUnitRunner.class)
 public class PatronOkapiClientTest {
 
-  private static final Logger logger = Logger.getLogger(PatronOkapiClientTest.class);
+  private static final Logger logger = LogManager.getLogger(PatronOkapiClientTest.class);
 
   private final String patronId = UUID.randomUUID().toString();
   private final String itemId = UUID.randomUUID().toString();


### PR DESCRIPTION
The referenced ticket is originally for CVE-2021-44228.
However, that CVE does not exactly affect the 1.2 versions of Log4J (per-say).
A separate CVE (CVE-2021-4104) appears to have been created to reference a way to exploit the JNDI expoit mentioned in CVE-2021-4428 via the JMSAppender.

This required several additional code changes and should be reviewed for breaking changes.
I have tested that, with the changes applied, the logs do work with 2.16.0.
I am not familiar with `jcl-over-slf4j` and as such I am concerned with potential for breakage there.

The dependencies now look like:
```
[INFO] -----------------------< org.folio:edge-patron >------------------------
[INFO] Building Edge API - Patron Empowerment 4.5.0
[INFO] --------------------------------[ jar ]---------------------------------
[INFO]
[INFO] --- maven-dependency-plugin:2.8:tree (default-cli) @ edge-patron ---
[INFO] org.folio:edge-patron:jar:4.5.0
[INFO] +- org.folio:edge-common:jar:2.0.2:compile
[INFO] |  \- log4j:log4j:jar:1.2.17:compile
[INFO] +- org.apache.logging.log4j:log4j-api:jar:2.16.0:compile
[INFO] +- org.apache.logging.log4j:log4j-core:jar:2.16.0:compile
[INFO] \- org.apache.logging.log4j:log4j-1.2-api:jar:2.16.0:compile
[INFO] ------------------------------------------------------------------------
```

Using an exclusion on log4j:log4j in org.folio:edge-common causes logs to not show up.
This concerns me that more work is needed.

Ticket is:  [EDGPATRON-69](https://issues.folio.org/browse/EDGPATRON-69).