### PR TITLE
EDGPATRON-79 Support circulation interface v13

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -9,7 +9,7 @@
     },
     {
       "id": "circulation",
-      "version": "9.5 10.0 11.0 12.0"
+      "version": "9.5 10.0 11.0 12.0 13.0"
     },
     {
       "id": "login",


### PR DESCRIPTION
### Purpose
Adapt the module to changed interface of mod-circulation from v12.0 to v13.0
### Approach
Adapt ModuleDescriptor-template to circulation interface v13.0;
### Learning
https://issues.folio.org/browse/EDGPATRON-79
