### PR TITLE
EDGPATRON-83 Use new api-lint and api-doc CI facilities

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,9 +1,9 @@
 buildMvn {
   publishModDescriptor = 'yes'
-  publishAPI = 'yes'
   mvnDeploy = 'yes'
 
   doApiLint = true
+  doApiDoc = true
   apiTypes = 'RAML'
   apiDirectories = 'ramls'
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -2,7 +2,10 @@ buildMvn {
   publishModDescriptor = 'yes'
   publishAPI = 'yes'
   mvnDeploy = 'yes'
-  runLintRamlCop = 'yes'
+
+  doApiLint = true
+  apiTypes = 'RAML'
+  apiDirectories = 'ramls'
 
   buildNode = 'jenkins-agent-java11'
   doDocker = {

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # edge-patron
 
-Copyright (C) 2018-2019 The Open Library Foundation
+Copyright (C) 2018-2022 The Open Library Foundation
 
 This software is distributed under the terms of the Apache License,
 Version 2.0. See the file "[LICENSE](LICENSE)" for more information.

--- a/ramls/account.json
+++ b/ramls/account.json
@@ -18,17 +18,17 @@
     "totalChargesCount": {
       "type": "integer",
       "description": "The total number of fines and charges for the patron",
-      "example": "10"
+      "example": 10
     },
     "totalLoans": {
       "type": "integer",
       "description": "The total number of items loaned to the patron",
-      "example": "10"
+      "example": 10
     },
     "totalHolds": {
       "type": "integer",
       "description": "The total number of requested items for the patron",
-      "example": "10"
+      "example": 10
     },
     "charges": {
       "type": "array",

--- a/ramls/edge-patron.raml
+++ b/ramls/edge-patron.raml
@@ -86,7 +86,7 @@ types:
             description: Returns the user account info
             body:
               application/json:
-                schema: account
+                type: account
                 example: !include examples/account.json
           400:
             description: Bad request
@@ -134,7 +134,7 @@ types:
                   description: Returns the renewed loan data
                   body:
                     application/json:
-                      schema: loan
+                      type: loan
                       example: !include examples/loan.json
                 400:
                   description: Bad request
@@ -174,7 +174,7 @@ types:
                   type: string
               body:
                 application/json:
-                  schema: hold
+                  type: hold
                   example: !include examples/hold.json
               responses:
                 201:
@@ -182,7 +182,7 @@ types:
                     Returns data for a new hold request on the specified item
                   body:
                     application/json:
-                      schema: hold
+                      type: hold
                       example: !include examples/hold.json
                 400:
                   description: Bad request
@@ -229,7 +229,7 @@ types:
                   type: string
               body:
                 application/json:
-                  schema: hold
+                  type: hold
                   example: !include examples/hold.json
               responses:
                 201:
@@ -237,7 +237,7 @@ types:
                     Returns data for a new hold request on the selected item
                   body:
                     application/json:
-                      schema: hold
+                      type: hold
                       example: !include examples/hold.json
                 400:
                   description: Bad request
@@ -263,7 +263,7 @@ types:
                   description: Validation error
                   body:
                     application/json:
-                      schema : errors
+                      type : errors
                 500:
                   description: |
                     Internal server error, e.g. due to misconfiguration
@@ -290,14 +290,14 @@ types:
                   type: string
               body:
                 application/json:
-                  schema: hold-cancellation
+                  type: hold-cancellation
                   example: !include examples/hold-cancellation.json
               responses:
                 201:
                   description: The specified hold request was removed
                   body:
                     application/json:
-                      schema: hold
+                      type: hold
                       example: !include examples/hold.json
                 400:
                   description: Bad request

--- a/ramls/money.json
+++ b/ramls/money.json
@@ -8,7 +8,7 @@
     "amount": {
       "type": "number",
       "description": "The amount of the fine or charge",
-      "example": "3.14"
+      "example": 3.14
     },
     "isoCurrencyCode": {
       "type": "string",


### PR DESCRIPTION
[EDGPATRON-83](https://issues.folio.org/browse/EDGPATRON-83)
[FOLIO-3231](https://issues.folio.org/browse/FOLIO-3231)

The doApiLint facility replaces runLintRamlCop
https://dev.folio.org/guides/api-lint/

The doApiDoc facility replaces publishAPI
https://dev.folio.org/guides/api-doc/
