### PR TITLE
EDGPATRON-91: Upgrade dependencies fixing DoS and HTTP Request Smuggling

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 
     <!-- the main class -->
     <exec.mainClass>org.folio.edge.patron.MainVerticle</exec.mainClass>
-    <vertx.version>4.1.0</vertx.version>
+    <vertx.version>4.3.1</vertx.version>
   </properties>
 
   <dependencyManagement>
@@ -48,14 +48,14 @@
       <dependency>
         <groupId>com.fasterxml.jackson</groupId>
         <artifactId>jackson-bom</artifactId>
-        <version>2.9.6</version>
+        <version>2.13.3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-bom</artifactId>
-        <version>2.17.0</version>
+        <version>2.17.2</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -77,8 +77,8 @@
     </dependency>
     <dependency>
       <groupId>io.jsonwebtoken</groupId>
-      <artifactId>jjwt</artifactId>
-      <version>0.6.0</version>
+      <artifactId>jjwt-api</artifactId>
+      <version>0.11.5</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
@@ -98,7 +98,7 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-ssm</artifactId>
-      <version>1.11.313</version>
+      <version>1.12.246</version>
       <exclusions>
         <exclusion>
           <groupId>commons-logging</groupId>
@@ -109,14 +109,14 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpcore</artifactId>
-      <version>4.4.9</version>
+      <version>4.4.15</version>
     </dependency>
 
     <!-- Only needed for VaultStore -->
     <dependency>
       <groupId>com.bettercloud</groupId>
       <artifactId>vault-java-driver</artifactId>
-      <version>3.1.0</version>
+      <version>5.1.0</version>
     </dependency>
 
     <dependency>
@@ -139,6 +139,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Upgrade woodstox-core from 5.0.3 to 6.2.7 fixing XML External Entity (XXE) Injection: https://security.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLWOODSTOX-2928754

Upgrade jackson-databind from 2.11.3 to 2.13.2.1 fixing Denial of Service (DoS): https://nvd.nist.gov/vuln/detail/CVE-2020-36518 , https://app.snyk.io/vuln/SNYK-JAVA-COMFASTERXMLJACKSONCORE-2326698

Upgrade jackson-dataformat-cbor from 2.11.3 to 2.13.2 fixing Denial of Service (DoS): https://nvd.nist.gov/vuln/detail/CVE-2020-36518

Upgrade vertx from 4.1.0 to 4.3.1. This indirectly upgrades Netty from 4.1.65.Final to 4.1.77.Final fixing Denial of Service (DoS), HTTP Request Smuggling, and Information Exposure: https://nvd.nist.gov/view/vuln/detail?vulnId=CVE-2021-37136 , https://nvd.nist.gov/view/vuln/detail?vulnId=CVE-2021-37137 , https://nvd.nist.gov/view/vuln/detail?vulnId=CVE-2021-43797 , https://nvd.nist.gov/view/vuln/detail?vulnId=CVE-2022-24823

Upgrade aws-java-sdk-ssm from 1.11.313 to 1.12.246 fixing Information Exposure: https://security.snyk.io/vuln/SNYK-JAVA-COMMONSCODEC-561518

Also upgrade other dependencies.