### PR TITLE
EDGPATRON-92: Replace CompletableFuture with Future, fix spurious failures

### DIFF
--- a/src/main/java/org/folio/edge/patron/PatronHandler.java
+++ b/src/main/java/org/folio/edge/patron/PatronHandler.java
@@ -82,17 +82,16 @@ public class PatronHandler extends Handler {
       final PatronOkapiClient patronClient = new PatronOkapiClient(client);
 
       PatronIdHelper.lookupPatron(patronClient, client.tenant, extPatronId)
-        .thenAcceptAsync(patronId -> {
+        .onSuccess(patronId -> {
           params.put(PARAM_PATRON_ID, patronId);
           action.apply(patronClient, params);
         })
-        .exceptionally(t -> {
+        .onFailure(t -> {
           if (t instanceof TimeoutException) {
             requestTimeout(ctx, t.getMessage());
           } else {
             notFound(ctx, "Unable to find patron " + extPatronId);
           }
-          return null;
         });
     });
   }

--- a/src/main/java/org/folio/edge/patron/utils/PatronIdHelper.java
+++ b/src/main/java/org/folio/edge/patron/utils/PatronIdHelper.java
@@ -29,8 +29,8 @@ public class PatronIdHelper {
     }
 
     return client.getPatron(extPatronId)
-        .onSuccess(internalId -> logger.info(String.format("Patron lookup successful: %s -> %s", extPatronId, internalId)))
-        .onFailure(t -> logger.error("Patron lookup failed for " + extPatronId, t));
+        .onSuccess(internalId -> logger.info("Patron lookup successful: {} -> {}", extPatronId, internalId))
+        .onFailure(t -> logger.error("Patron lookup failed for {}", extPatronId, t));
   }
 
 }

--- a/src/main/java/org/folio/edge/patron/utils/PatronIdHelper.java
+++ b/src/main/java/org/folio/edge/patron/utils/PatronIdHelper.java
@@ -1,7 +1,6 @@
 package org.folio.edge.patron.utils;
 
-import java.util.concurrent.CompletableFuture;
-
+import io.vertx.core.Future;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.edge.core.cache.TokenCache.NotInitializedException;
@@ -15,9 +14,7 @@ public class PatronIdHelper {
 
   }
 
-  public static CompletableFuture<String> lookupPatron(PatronOkapiClient client, String tenant, String extPatronId) {
-    CompletableFuture<String> future = new CompletableFuture<>();
-
+  public static Future<String> lookupPatron(PatronOkapiClient client, String tenant, String extPatronId) {
     String patronId = null;
     try {
       PatronIdCache cache = PatronIdCache.getInstance();
@@ -28,18 +25,12 @@ public class PatronIdHelper {
 
     if (patronId != null) {
       logger.info("Using cached patronId");
-      future.complete(patronId);
-    } else {
-      client.getPatron(extPatronId).thenAcceptAsync(internalId -> {
-        logger.info(String.format("Patron lookup successful: %s -> %s", extPatronId, internalId));
-        future.complete(internalId);
-      }).exceptionally(t -> {
-        logger.error("Patron lookup failed for " + extPatronId, t);
-        future.completeExceptionally(t);
-        return null;
-      });
+      return Future.succeededFuture(patronId);
     }
-    return future;
+
+    return client.getPatron(extPatronId)
+        .onSuccess(internalId -> logger.info(String.format("Patron lookup successful: %s -> %s", extPatronId, internalId)))
+        .onFailure(t -> logger.error("Patron lookup failed for " + extPatronId, t));
   }
 
 }

--- a/src/main/java/org/folio/edge/patron/utils/PatronOkapiClient.java
+++ b/src/main/java/org/folio/edge/patron/utils/PatronOkapiClient.java
@@ -53,20 +53,20 @@ public class PatronOkapiClient extends OkapiClient {
           String bodyStr = resp.bodyAsString();
           logger.info(String.format("Response from mod-users: (%s) body: %s", status, bodyStr));
           if (status != 200) {
-            promise.fail(new PatronLookupException(bodyStr));
+            promise.tryFail(new PatronLookupException(bodyStr));
           } else {
             JsonObject json = resp.bodyAsJsonObject();
             try {
-              promise.complete(json.getJsonArray("users").getJsonObject(0).getString("id"));
+              promise.tryComplete(json.getJsonArray("users").getJsonObject(0).getString("id"));
             } catch (Exception e) {
               logger.error("Exception parsing response from mod-users", e);
-              promise.fail(new PatronLookupException(e));
+              promise.tryFail(new PatronLookupException(e));
             }
           }
         },
         t -> {
           logger.error("Exception calling mod-users", t);
-          promise.fail(new PatronLookupException(t));
+          promise.tryFail(new PatronLookupException(t));
         });
     return promise.future();
   }

--- a/src/test/java/org/folio/edge/patron/MainVerticleTest.java
+++ b/src/test/java/org/folio/edge/patron/MainVerticleTest.java
@@ -431,7 +431,7 @@ public class MainVerticleTest {
     int expectedStatusCode = 408;
     final Response resp = RestAssured
       .with()
-      .header(X_DURATION, requestTimeoutMs * 2)
+      .header(X_DURATION, requestTimeoutMs * 3)
       .get(String.format("/patron/account/%s?apikey=%s", patronId, apiKey))
       .then()
       .contentType(APPLICATION_JSON)
@@ -551,7 +551,7 @@ public class MainVerticleTest {
 
     final Response resp = RestAssured
       .with()
-      .header(X_DURATION, requestTimeoutMs * 2)
+      .header(X_DURATION, requestTimeoutMs * 3)
       .post(String.format("/patron/account/%s/item/%s/renew?apikey=%s", patronId, itemId,
           apiKey))
       .then()
@@ -762,7 +762,7 @@ public class MainVerticleTest {
     final Response resp = RestAssured
       .with()
       .body(hold.toJson())
-      .header(X_DURATION, requestTimeoutMs * 2)
+      .header(X_DURATION, requestTimeoutMs * 3)
       .contentType(APPLICATION_JSON)
       .post(
           String.format("/patron/account/%s/instance/%s/hold?apikey=%s", patronId, instanceId,
@@ -989,7 +989,7 @@ public class MainVerticleTest {
     final Response resp = RestAssured
       .with()
       .body(hold.toJson())
-      .header(X_DURATION, requestTimeoutMs * 2)
+      .header(X_DURATION, requestTimeoutMs * 3)
       .contentType(APPLICATION_JSON)
       .post(
           String.format("/patron/account/%s/item/%s/hold?apikey=%s", patronId, itemId,
@@ -1207,7 +1207,7 @@ public class MainVerticleTest {
 
     final Response resp = RestAssured
       .with()
-      .header(X_DURATION, requestTimeoutMs * 2)
+      .header(X_DURATION, requestTimeoutMs * 3)
       .contentType(APPLICATION_JSON)
       .body(cancedHoldJson)
       .post(String.format("/patron/account/%s/hold/%s/cancel?apikey=%s", extPatronId, holdCancellationHoldId,
@@ -1355,7 +1355,7 @@ public class MainVerticleTest {
     final Response resp = RestAssured
       .with()
       .contentType(APPLICATION_JSON)
-      .header(X_DURATION, requestTimeoutMs * 2)
+      .header(X_DURATION, requestTimeoutMs * 3)
       .body(canceledHold)
       .post(String.format("/patron/account/%s/hold/%s/cancel?apikey=%s", extPatronId, holdId, apiKey))
       .then()

--- a/src/test/java/org/folio/edge/patron/utils/PatronOkapiClientTest.java
+++ b/src/test/java/org/folio/edge/patron/utils/PatronOkapiClientTest.java
@@ -67,8 +67,8 @@ public class PatronOkapiClientTest {
 
     client.login("admin", "password").get();
     assertEquals(MOCK_TOKEN, client.getToken());
-    String patronId = client.getPatron(PatronMockOkapi.extPatronId).get();
-    assertEquals(PatronMockOkapi.patronId, patronId);
+    client.getPatron(PatronMockOkapi.extPatronId)
+    .onComplete(context.asyncAssertSuccess(patronId -> assertEquals(PatronMockOkapi.patronId, patronId)));
   }
 
   @Test
@@ -77,30 +77,24 @@ public class PatronOkapiClientTest {
 
     client.login("admin", "password").get();
     assertEquals(MOCK_TOKEN, client.getToken());
-    try {
-      client.getPatron(PatronMockOkapi.extPatronId_notFound).get();
-      fail("Expected " + PatronLookupException.class.getName() + " to be thrown");
-    } catch (Exception e) {
-      if (!(e.getCause() instanceof PatronLookupException)) {
-        fail("Expected " + PatronLookupException.class.getName() + " got " + e.getCause().getClass().getName());
-        throw e;
+    client.getPatron(PatronMockOkapi.extPatronId_notFound)
+    .onComplete(context.asyncAssertFailure(e -> {
+      if (!(e instanceof PatronLookupException)) {
+        fail("Expected " + PatronLookupException.class.getName() + " got " + e.getClass().getName());
       }
-    }
+    }));
   }
 
   @Test
   public void testGetPatronInsufficientPrivs(TestContext context) throws Exception {
     logger.info("=== Test getPatron patron doesn't exist ===");
 
-    try {
-      client.getPatron(PatronMockOkapi.extPatronId).get();
-      fail("Expected " + PatronLookupException.class.getName() + " to be thrown");
-    } catch (Exception e) {
-      if (!(e.getCause() instanceof PatronLookupException)) {
-        fail("Expected " + PatronLookupException.class.getName() + " got " + e.getCause().getClass().getName());
-        throw e;
+    client.getPatron(PatronMockOkapi.extPatronId)
+    .onComplete(context.asyncAssertFailure(e -> {
+      if (!(e instanceof PatronLookupException)) {
+        fail("Expected " + PatronLookupException.class.getName() + " got " + e.getClass().getName());
       }
-    }
+    }));
   }
 
   @Test


### PR DESCRIPTION
Timeout tests like MainVerticleTest.testPlaceInstanceHoldRequestTimeout have spurious test failures because CompletableFuture and Future may block each other:

```
12:46:48 INFO  MockOkapi            Waiting for 6000 ms before continuing
12:46:51 ERROR PatronHandler        Exception calling OKAPI
io.vertx.core.VertxException: Connection was closed
12:46:51 ERROR ?                    io.vertx.core.VertxException: Connection was closed
12:46:51 DEBUG Wire                  << "HTTP/1.1 500 Internal Server Error[\r][\n]"
12:46:51 DEBUG Wire                  << "content-type: application/json[\r][\n]"
12:46:51 DEBUG Wire                  << "content-length: 62[\r][\n]"
12:46:51 DEBUG Wire                  << "[\r][\n]"
12:46:51 DEBUG aultClientConnection Receiving response: HTTP/1.1 500 Internal Server Error
```

```
[ERROR]   MainVerticleTest.testPlaceItemHoldRequestTimeout:999 1 expectation failed.
Expected status code <408> but was <500>.
```

Solution: Replace CompletableFuture with Future