### PR TITLE
EDGPATRON-93: Replace IOUtils.toString by readAllBytes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -183,12 +183,6 @@
       <version>4.3.0</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-      <version>2.6</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/src/test/java/org/folio/edge/patron/utils/PatronMockOkapi.java
+++ b/src/test/java/org/folio/edge/patron/utils/PatronMockOkapi.java
@@ -18,7 +18,8 @@ import static org.folio.edge.patron.Constants.PARAM_REQUEST_ID;
 import static org.folio.edge.patron.Constants.PARAM_SORT_BY;
 
 import java.io.IOException;
-import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -26,8 +27,6 @@ import java.util.Currency;
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;
-
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -672,17 +671,10 @@ public class PatronMockOkapi extends MockOkapi {
 
   public static String readMockFile(final String path) {
     try {
-      final InputStream is = PatronMockOkapi.class.getResourceAsStream(path);
-
-      if (is != null) {
-        return IOUtils.toString(is, "UTF-8");
-      } else {
-        return "";
-      }
-    } catch (Throwable e) {
-      logger.error(String.format("Unable to read mock configuration in %s file", path));
+      return new String(PatronMockOkapi.class.getResourceAsStream(path).readAllBytes(),
+          StandardCharsets.UTF_8);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
     }
-
-    return "";
   }
 }


### PR DESCRIPTION
This clears the false positive GitHub dependabot alert
"Path Traversal and Improper Input Validation in Apache Commons IO".