### PR TITLE
EDGPATRON-95: Upgrade mockito from 1.95 to 4.6.1 for Java 17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,8 +161,8 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-all</artifactId>
-      <version>1.9.5</version>
+      <artifactId>mockito-core</artifactId>
+      <version>4.6.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/test/java/org/folio/edge/patron/MainVerticleTest.java
+++ b/src/test/java/org/folio/edge/patron/MainVerticleTest.java
@@ -24,7 +24,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.junit.Assert.assertNull;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;


### PR DESCRIPTION
How to reproduce: Use Java 17, run mvn clean install.

Expected: succeeds

Actual: fails with this error

```
[ERROR] org.folio.edge.patron.MainVerticleTest  Time elapsed: 1.124 s  <<< ERROR!
java.lang.ExceptionInInitializerError
        at org.folio.edge.patron.MainVerticleTest.setUpOnce(MainVerticleTest.java:94)
Caused by: java.lang.reflect.InaccessibleObjectException: Unable to make protected final java.lang.Class java.lang.ClassLoader.defineClass(java.lang.String,byte[],int,int,java.security.ProtectionDomain) throws java.lang.ClassFormatError accessible: module java.base does not "opens java.lang" to unnamed module @62bd2070
        at org.folio.edge.patron.MainVerticleTest.setUpOnce(MainVerticleTest.java:94)
```

Fix: Use latest mockito.