### PR TITLE
EDGPATRON-99: Bump to Vert.x 4.3.3 and edge-common 4.4.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
 
     <!-- the main class -->
     <exec.mainClass>org.folio.edge.patron.MainVerticle</exec.mainClass>
-    <vertx.version>4.3.1</vertx.version>
+    <vertx.version>4.3.3</vertx.version>
   </properties>
 
   <dependencyManagement>
@@ -107,7 +107,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>edge-common</artifactId>
-      <version>4.4.0</version>
+      <version>4.4.1</version>
     </dependency>
 
     <!-- Only needed for AwsParamStore -->


### PR DESCRIPTION
This fixes disabled SSL in Vert.x 4.3.0/4.3.1.