### PR TITLE
EDGPATRON-101: Improve error logging for external requests

### DIFF
--- a/src/main/java/org/folio/edge/patron/PatronHandler.java
+++ b/src/main/java/org/folio/edge/patron/PatronHandler.java
@@ -85,6 +85,7 @@ public class PatronHandler extends Handler {
           action.apply(patronClient, params);
         })
         .onFailure(t -> {
+          logger.error("Error retrieving user data from cache or mod-user");
           if (isTimeoutException(t)) {
             requestTimeout(ctx, t.getMessage());
           } else {
@@ -256,7 +257,7 @@ public class PatronHandler extends Handler {
 
   @Override
   protected void handleProxyException(RoutingContext ctx, Throwable t) {
-    logger.error("Exception calling OKAPI", t);
+    logger.error("Exception retrieving data from mod-patron:", t);
     if (isTimeoutException(t)) {
       requestTimeout(ctx, t.getMessage());
     } else {

--- a/src/main/java/org/folio/edge/patron/PatronHandler.java
+++ b/src/main/java/org/folio/edge/patron/PatronHandler.java
@@ -85,7 +85,7 @@ public class PatronHandler extends Handler {
           action.apply(patronClient, params);
         })
         .onFailure(t -> {
-          logger.error("Error retrieving user data from cache or mod-user");
+          logger.error("Error retrieving user data from cache or mod-user: ", t);
           if (isTimeoutException(t)) {
             requestTimeout(ctx, t.getMessage());
           } else {


### PR DESCRIPTION
Edge-patron only communicates with two external modules:
mod-user (to look up the users UUID)
Mod-patron (everything else)
I've attached error messages to both that identify what module call was connected with the failure.