### PR TITLE
EDGPATRON-123: Vert.x 4.4.6, Netty 4.1.100.Final

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,22 +33,22 @@
 
     <!-- the main class -->
     <exec.mainClass>org.folio.edge.patron.MainVerticle</exec.mainClass>
-    <vertx.version>4.3.5</vertx.version>
+    <vertx.version>4.4.6</vertx.version>
   </properties>
 
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-stack-depchain</artifactId>
-        <version>${vertx.version}</version>
+        <groupId>org.apache.logging.log4j</groupId>
+        <artifactId>log4j-bom</artifactId>
+        <version>2.19.0</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-bom</artifactId>
-        <version>2.19.0</version>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-stack-depchain</artifactId>
+        <version>${vertx.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Upgrade Vert.x from 4.3.5 to 4.4.6. This indirectly upgrades Netty from 4.1.85.Final to 4.1.100.Final fixing Denial of Service (DoS) and HTTP Response Splitting:
https://nvd.nist.gov/vuln/detail/CVE-2023-44487
https://nvd.nist.gov/vuln/detail/CVE-2022-41915
https://nvd.nist.gov/vuln/detail/CVE-2023-34462

Move log4j-bom before vertx-stack-depchain in dependencyManagement so that vertx doesn't downgrade some log4j versions resulting in version mismatch with "NoSuchMethodError: org.apache.logging.log4j.util.StackLocatorUtil.getCurrentStackTrace()"