### PR TITLE
EDGPATRON-139: Bump up edge-common to v4.7.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>edge-common</artifactId>
-      <version>4.7.0</version>
+      <version>4.7.1</version>
     </dependency>
 
     <!-- Only needed for AwsParamStore -->


### PR DESCRIPTION
bump up edge-common to v4.7.1: AwsParamStore to support FIPS-approved crypto modules