### PR TITLE
EDGPATRON-147 Patron lookup in the secure tenant

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -27,9 +27,9 @@
       }
     },
     "env": [
-      { "name": "JAVA_OPTIONS",
-        "value": "-XX:MaxRAMPercentage=66.0"
-      }
+      { "name": "JAVA_OPTIONS", "value": "-XX:MaxRAMPercentage=66.0"},
+      { "name": "SECURE_REQUESTS_FEATURE_ENABLED", "value": "false"},
+      { "name": "SECURE_TENANT_ID", "value": "securetenant"}
     ]
   }
 }

--- a/src/main/java/org/folio/edge/patron/utils/PatronOkapiClient.java
+++ b/src/main/java/org/folio/edge/patron/utils/PatronOkapiClient.java
@@ -85,7 +85,7 @@ public class PatronOkapiClient extends OkapiClient {
       String bodyStr = response.bodyAsString();
       logger.info(format("Response from %s: (%s) body: %s", moduleName, status, bodyStr));
       if (status != 200) {
-        promise.tryFail(new PatronLookupException(status, bodyStr));
+        promise.tryFail(new PatronLookupException(bodyStr));
       } else {
         JsonObject json = response.bodyAsJsonObject();
         try {
@@ -263,19 +263,12 @@ public class PatronOkapiClient extends OkapiClient {
 
     private static final long serialVersionUID = -8671018675309863637L;
 
-    private int httpStatus;
-
     public PatronLookupException(Throwable t) {
       super(t);
     }
 
-    public PatronLookupException(int httpStatus, String msg) {
+    public PatronLookupException(String msg) {
       super(msg);
-      this.httpStatus = httpStatus;
-    }
-
-    public int getHttpStatus() {
-      return httpStatus;
     }
   }
 

--- a/src/test/java/org/folio/edge/patron/utils/PatronMockOkapi.java
+++ b/src/test/java/org/folio/edge/patron/utils/PatronMockOkapi.java
@@ -68,8 +68,8 @@ public class PatronMockOkapi extends MockOkapi {
   public static final String patronId_notFound = UUID.randomUUID().toString();
   public static final String extPatronId = UUID.randomUUID().toString();
   public static final String extPatronId_notFound = UUID.randomUUID().toString();
-  public static final String extSecurePatronId = UUID.randomUUID().toString();
-  public static final String extSecurePatronId_notFound = UUID.randomUUID().toString();
+  public static final String EXT_SECURE_PATRON_ID = UUID.randomUUID().toString();
+  public static final String EXT_SECURE_PATRON_ID_NOT_FOUND = UUID.randomUUID().toString();
   public static final String feeFineId = UUID.randomUUID().toString();
   public static final String itemId_reached_max_renewals = UUID.randomUUID().toString();
   public static final String itemId_reached_max_renewals_empty_error_msg = UUID.randomUUID().toString();
@@ -588,9 +588,9 @@ public class PatronMockOkapi extends MockOkapi {
   public static String getPatronJson(String patronId, boolean secure) {
     JsonArray users = new JsonArray();
     logger.info(patronId);
-    var nonSecureNonexistent = List.of(extPatronId_notFound, extSecurePatronId,
-      extSecurePatronId_notFound);
-    var secureNonexistent = List.of(extSecurePatronId_notFound, extPatronId, extPatronId_notFound);
+    var nonSecureNonexistent = List.of(extPatronId_notFound, EXT_SECURE_PATRON_ID,
+      EXT_SECURE_PATRON_ID_NOT_FOUND);
+    var secureNonexistent = List.of(EXT_SECURE_PATRON_ID_NOT_FOUND, extPatronId, extPatronId_notFound);
     if (!(secure ? secureNonexistent : nonSecureNonexistent).contains(patronId)) {
       users.add(new JsonObject()
         .put("externalSystemId", patronId)

--- a/src/test/java/org/folio/edge/patron/utils/PatronMockOkapi.java
+++ b/src/test/java/org/folio/edge/patron/utils/PatronMockOkapi.java
@@ -68,6 +68,8 @@ public class PatronMockOkapi extends MockOkapi {
   public static final String patronId_notFound = UUID.randomUUID().toString();
   public static final String extPatronId = UUID.randomUUID().toString();
   public static final String extPatronId_notFound = UUID.randomUUID().toString();
+  public static final String extSecurePatronId = UUID.randomUUID().toString();
+  public static final String extSecurePatronId_notFound = UUID.randomUUID().toString();
   public static final String feeFineId = UUID.randomUUID().toString();
   public static final String itemId_reached_max_renewals = UUID.randomUUID().toString();
   public static final String itemId_reached_max_renewals_empty_error_msg = UUID.randomUUID().toString();
@@ -131,6 +133,9 @@ public class PatronMockOkapi extends MockOkapi {
     router.route(HttpMethod.GET, "/users")
       .handler(this::getPatronHandler);
 
+    router.route(HttpMethod.GET, "/circulation-bff/external-users/:extPatronId/tenant/:tenantId")
+      .handler(this::getSecurePatronHandler);
+
     router.route(HttpMethod.GET, "/patron/account/:patronId")
       .handler(this::getAccountHandler);
 
@@ -182,7 +187,23 @@ public class PatronMockOkapi extends MockOkapi {
       ctx.response()
         .setStatusCode(200)
         .putHeader(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON)
-        .end(getPatronJson(extPatronId));
+        .end(getPatronJson(extPatronId, false));
+    }
+  }
+
+  public void getSecurePatronHandler(RoutingContext ctx) {
+    String token = ctx.request().getHeader(X_OKAPI_TOKEN);
+
+    if (token == null || !token.equals(MOCK_TOKEN)) {
+      ctx.response()
+        .setStatusCode(403)
+        .putHeader(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN)
+        .end("Access requires permission: users.collection.get");
+    } else {
+      ctx.response()
+        .setStatusCode(200)
+        .putHeader(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON)
+        .end(getPatronJson(ctx.pathParam("extPatronId"), true));
     }
   }
 
@@ -564,14 +585,16 @@ public class PatronMockOkapi extends MockOkapi {
     }
   }
 
-  public static String getPatronJson(String extPatronId) {
+  public static String getPatronJson(String patronId, boolean secure) {
     JsonArray users = new JsonArray();
-    logger.info(extPatronId_notFound);
-    logger.info(extPatronId);
-    if (!extPatronId_notFound.equals(extPatronId)) {
+    logger.info(patronId);
+    var nonSecureNonexistent = List.of(extPatronId_notFound, extSecurePatronId,
+      extSecurePatronId_notFound);
+    var secureNonexistent = List.of(extSecurePatronId_notFound, extPatronId, extPatronId_notFound);
+    if (!(secure ? secureNonexistent : nonSecureNonexistent).contains(patronId)) {
       users.add(new JsonObject()
-        .put("externalSystemId", extPatronId)
-        .put("id", patronId));
+        .put("externalSystemId", patronId)
+        .put("id", PatronMockOkapi.patronId));
     }
 
     JsonObject json = new JsonObject()

--- a/src/test/java/org/folio/edge/patron/utils/PatronOkapiClientTest.java
+++ b/src/test/java/org/folio/edge/patron/utils/PatronOkapiClientTest.java
@@ -6,13 +6,14 @@ import static org.folio.edge.patron.utils.PatronMockOkapi.offset_param;
 import static org.folio.edge.patron.utils.PatronMockOkapi.wrongIntegerParamMessage;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
-import io.vertx.core.json.JsonObject;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.edge.core.utils.OkapiClientFactory;
@@ -26,6 +27,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
@@ -54,8 +56,8 @@ public class PatronOkapiClientTest {
     mockOkapi.start()
     .onComplete(context.asyncAssertSuccess());
 
-    client = new PatronOkapiClient(new OkapiClientFactory(Vertx.vertx(),
-      "http://localhost:" + okapiPort, reqTimeout).getOkapiClient(tenant), "alternateTenantId");
+    client = spy(new PatronOkapiClient(new OkapiClientFactory(Vertx.vertx(),
+      "http://localhost:" + okapiPort, reqTimeout).getOkapiClient(tenant), "alternateTenantId"));
   }
 
   @After
@@ -86,6 +88,36 @@ public class PatronOkapiClientTest {
         fail("Expected " + PatronLookupException.class.getName() + " got " + e.getClass().getName());
       }
     }));
+  }
+
+  @Test
+  public void testGetPatronExistingSecurePatron(TestContext context) throws Exception {
+    logger.info("=== Test getPatron patron doesn't exist in local mod-user but exists in Secure " +
+      "tenant's mod-user and accessible through mod-circulation-bff, " +
+      "secure requests feature is enabled ===");
+
+    client.login("admin", "password").get();
+    assertEquals(MOCK_TOKEN, client.getToken());
+    when(client.isSecureRequestsFeatureEnabled()).thenReturn(true);
+    client.getPatron(PatronMockOkapi.extSecurePatronId)
+      .onComplete(context.asyncAssertSuccess(
+        patronId -> assertEquals(PatronMockOkapi.patronId, patronId)));
+  }
+
+  @Test
+  public void testGetPatronNonexistentSecurePatron(TestContext context) throws Exception {
+    logger.info("=== Test getPatron patron doesn't exist in both secure and non-secure mod-user," +
+      "secure requests feature is enabled ===");
+
+    client.login("admin", "password").get();
+    assertEquals(MOCK_TOKEN, client.getToken());
+    when(client.isSecureRequestsFeatureEnabled()).thenReturn(true);
+    client.getPatron(PatronMockOkapi.extSecurePatronId_notFound)
+      .onComplete(context.asyncAssertFailure(e -> {
+        if (!(e instanceof PatronLookupException)) {
+          fail("Expected " + PatronLookupException.class.getName() + " got " + e.getClass().getName());
+        }
+      }));
   }
 
   @Test

--- a/src/test/java/org/folio/edge/patron/utils/PatronOkapiClientTest.java
+++ b/src/test/java/org/folio/edge/patron/utils/PatronOkapiClientTest.java
@@ -99,9 +99,9 @@ public class PatronOkapiClientTest {
     client.login("admin", "password").get();
     assertEquals(MOCK_TOKEN, client.getToken());
     when(client.isSecureRequestsFeatureEnabled()).thenReturn(true);
-    client.getPatron(PatronMockOkapi.extSecurePatronId)
+    client.getPatron(PatronMockOkapi.EXT_SECURE_PATRON_ID)
       .onComplete(context.asyncAssertSuccess(
-        patronId -> assertEquals(PatronMockOkapi.patronId, patronId)));
+        actualPatronId -> assertEquals(PatronMockOkapi.patronId, actualPatronId)));
   }
 
   @Test
@@ -112,7 +112,7 @@ public class PatronOkapiClientTest {
     client.login("admin", "password").get();
     assertEquals(MOCK_TOKEN, client.getToken());
     when(client.isSecureRequestsFeatureEnabled()).thenReturn(true);
-    client.getPatron(PatronMockOkapi.extSecurePatronId_notFound)
+    client.getPatron(PatronMockOkapi.EXT_SECURE_PATRON_ID_NOT_FOUND)
       .onComplete(context.asyncAssertFailure(e -> {
         if (!(e instanceof PatronLookupException)) {
           fail("Expected " + PatronLookupException.class.getName() + " got " + e.getClass().getName());


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/EDGPATRON-147

Assumption: feature flag for Secure Request and Secure Tenant ID are configured via environment variables

Expected logic: if we did not find a patron in the Central Tenant AND if the Secure Request feature is enabled, then call mod-users in the Congressional Tenant using `mod-circulation-bff`'s new endpoint (not implemented yet)