### PR TITLE
EDGPATRON-196: Document env variable SECURE_TENANT_ID in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,18 @@ If truststore parameters need to be populated, `FOLIO_CLIENT_TLS_TRUSTSTORETYPE`
 | `FOLIO_CLIENT_TLS_TRUSTSTOREPATH`       | `NA`              | Set the location of the keystore file in the local file system                   |
 | `FOLIO_CLIENT_TLS_TRUSTSTOREPASSWORD`   | `NA`              | Set the password for the keystore                                                |
 
+### Env variables for secure requests feature 
+
+| Property                                | Default           | Description                                                                          |
+|-----------------------------------------|-------------------|--------------------------------------------------------------------------------------|
+| `SECURE_REQUESTS_FEATURE_ENABLED`       | `false`           | true to enable secure requests                                                       |
+| `SECURE_TENANT_ID`                      | `secure`          | Tenant id for GET /circulation-bff/external-users/{externalUserId}/tenant/{tenantId} |
+
+The Secure tenant is in use for Library of Congress (LoC) in order to manage Congressional patrons' User records,
+protect their User information from staff members who are active in the Fulfillment process
+but cannot see private patron User information and house Items from a collection that only Congressional requesters can borrow.
+
+This tenant also houses the Mediated requests app, which is an app used by LoC in order to triage Congressional requests prior to their confirmation as proper Requests in the Requests app.
 
 ## Patron Mapping
 

--- a/src/main/java/org/folio/edge/patron/utils/PatronOkapiClient.java
+++ b/src/main/java/org/folio/edge/patron/utils/PatronOkapiClient.java
@@ -110,9 +110,8 @@ public class PatronOkapiClient extends OkapiClient {
       System.getenv().getOrDefault(SECURE_REQUESTS_FEATURE_ENABLED, FALSE.toString()));
   }
 
-  public boolean getSecureTenantId() {
-    return Boolean.parseBoolean(
-      System.getenv().getOrDefault(SECURE_TENANT_ID, null));
+  private static String getSecureTenantId() {
+    return System.getenv().getOrDefault(SECURE_TENANT_ID, "secure");
   }
 
   public void getAccount(PatronAccountRequestParams requestParams,

--- a/src/test/java/org/folio/edge/patron/utils/PatronMockOkapi.java
+++ b/src/test/java/org/folio/edge/patron/utils/PatronMockOkapi.java
@@ -219,12 +219,22 @@ public class PatronMockOkapi extends MockOkapi {
         .setStatusCode(403)
         .putHeader(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN)
         .end("Access requires permission: users.collection.get");
-    } else {
-      ctx.response()
-        .setStatusCode(200)
-        .putHeader(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON)
-        .end(getPatronJson(ctx.pathParam("extPatronId"), true));
+      return;
     }
+
+    var uri = ctx.request().absoluteURI();
+    if (!uri.endsWith("/secure")) {
+      ctx.response()
+        .setStatusCode(400)
+        .putHeader(HttpHeaders.CONTENT_TYPE, TEXT_PLAIN)
+        .end("Expected tailing /{tenantId} to be /secure but found " + uri);
+      return;
+    }
+
+    ctx.response()
+      .setStatusCode(200)
+      .putHeader(HttpHeaders.CONTENT_TYPE, APPLICATION_JSON)
+      .end(getPatronJson(ctx.pathParam("extPatronId"), true));
   }
 
   public void getAccountHandler(RoutingContext ctx) {


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/EDGPATRON-196

## Purpose
Document env variable SECURE_TENANT_ID in README.md

## Approach
Add new section in README.md.

Fix typo in code so that README and code match.

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [x] Code coverage on new code is 80% or greater
  - [x] Duplications on new code is 3% or less
  - [x] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [x] There are no breaking changes in this PR.